### PR TITLE
Add `json` param to Session.request.

### DIFF
--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -43,7 +43,7 @@ class Session(object):
         """Close the session and perform any clean up."""
         self._requestor._http.close()
 
-    def request(self, method, path, params=None, data=None):
+    def request(self, method, path, params=None, data=None, json=None):
         """Return the json content from the resource at ``path``.
 
         :param method: The request verb. E.g., get, post, put.
@@ -52,6 +52,8 @@ class Session(object):
         :param params: The query parameters to send with the request.
         :param data: Dictionary, bytes, or file-like object to send in the body
             of the request.
+        :param json: Object serialized to JSON to send in the body of the
+            request.
 
         """
         if not self._authorizer.is_valid():
@@ -74,7 +76,7 @@ class Session(object):
         response = self._rate_limiter.call(self._requestor._http.request,
                                            method, url, allow_redirects=False,
                                            data=data, headers=headers,
-                                           params=params)
+                                           params=params, json=json)
 
         log.debug('Response: {} ({} bytes)'.format(
             response.status_code, response.headers.get('content-length')))

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -66,6 +66,15 @@ class SessionTest(unittest.TestCase):
             self.assertIn('a_test_from_prawcore',
                           response['json']['data']['url'])
 
+    def test_request__patch(self):
+        with Betamax(REQUESTOR).use_cassette('Session_request__patch'):
+            session = prawcore.Session(script_authorizer())
+            json = {'lang': 'ja', 'num_comments': 123}
+            response = session.request('PATCH', '/api/v1/me/prefs',
+                                       json=json)
+            self.assertEqual('ja', response['lang'])
+            self.assertEqual(123, response['num_comments'])
+
     def test_request__raw_json(self):
         with Betamax(REQUESTOR).use_cassette(
                 'Session_request__raw_json'):


### PR DESCRIPTION
This commit allows users to send `PATCH /api/v1/me/prefs` request
via `Session.request`.