### PR TITLE
Add DeviceIDAuthorizer to support app-only OAuth2 for 'install' apps

### DIFF
--- a/examples/device_id_auth_trophies.py
+++ b/examples/device_id_auth_trophies.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+"""This example outputs a user's list of trophies.
+
+This program demonstrates the use of ``prawcore.DeviceIDAuthorizer``.
+"""
+
+import os
+import prawcore
+import sys
+
+
+def main():
+    """Provide the program's entry point when directly executed."""
+    if len(sys.argv) != 2:
+        print('Usage: {} USERNAME'.format(sys.argv[0]))
+        return 1
+
+    authenticator = prawcore.Authenticator(
+        prawcore.Requestor('prawcore_device_id_auth_example'),
+        os.environ['PRAWCORE_CLIENT_ID'],
+        os.environ['PRAWCORE_CLIENT_SECRET'])
+    authorizer = prawcore.DeviceIDAuthorizer(authenticator,
+                                             'DO_NOT_TRACK_THIS_DEVICE')
+    authorizer.refresh()
+
+    user = sys.argv[1]
+    with prawcore.session(authorizer) as session:
+        data = session.request('GET', '/api/v1/user/{}/trophies'.format(user))
+
+    for trophy in data['data']['trophies']:
+        description = trophy['data']['description']
+        print(trophy['data']['name'] +
+              (' ({})'.format(description) if description else ''))
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/prawcore/__init__.py
+++ b/prawcore/__init__.py
@@ -1,8 +1,8 @@
 """prawcore: Low-level communication layer for PRAW 4+."""
 
 import logging
-from .auth import (Authenticator, Authorizer, ReadOnlyAuthorizer,  # noqa
-                   ScriptAuthorizer)
+from .auth import (Authenticator, Authorizer, DeviceIDAuthorizer,  # noqa
+                   ReadOnlyAuthorizer, ScriptAuthorizer)
 from .const import __version__  # noqa
 from .exceptions import *  # noqa
 from .requestor import Requestor  # noqa

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -167,6 +167,34 @@ class Authorizer(object):
             self.refresh_token = None
 
 
+class DeviceIDAuthorizer(Authorizer):
+    """Manages app-only OAuth2 for 'installed' applications.
+
+    While the '*' scope will be available, some endpoints simply will not work
+    due to the lack of an associated reddit account.
+    """
+
+    def __init__(self, authenticator, device_id):
+        """Represents an app-only OAuth2 authorization for 'installed' apps.
+
+        :param authenticator: An instance of :class:`Authenticator`.
+        :param device_id: A unique ID (20-30 character ASCII string)
+            For more information about this parameter, see:
+            https://github.com/reddit/reddit/wiki/OAuth2#application-only-oauth
+        """
+        if authenticator.client_secret != '':
+            raise InvalidInvocation(
+                'confindential client cannot instantiate this class')
+        super(DeviceIDAuthorizer, self).__init__(authenticator)
+        self._device_id = device_id
+
+    def refresh(self):
+        """Obtain a new access token."""
+        grant_type = 'https://oauth.reddit.com/grants/installed_client'
+        self._request_token(grant_type=grant_type,
+                            device_id=self._device_id)
+
+
 class ReadOnlyAuthorizer(Authorizer):
     """Manages authorizations that are not associated with a reddit account.
 

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -9,12 +9,13 @@ from requests.status_codes import codes
 class Authenticator(object):
     """Stores OAuth2 authentication credentials."""
 
-    def __init__(self, requestor, client_id, client_secret, redirect_uri=None):
+    def __init__(self, requestor, client_id, client_secret=None, redirect_uri=None):
         """Represent a single authentication to reddit's API.
 
         :param requestor: An instance of :class:`Requestor`.
         :param client_id: The OAuth2 client ID to use with the session.
-        :param client_secret: The OAuth2 client secret to use with the session.
+        :param client_secret: (optional) The OAuth2 client secret to use
+            with the session.
         :param redirect_uri: (optional) The redirect URI exactly as specified
             in your OAuth application settings on reddit. This parameter is
             required if you want to use the ``authorize_url`` method, or the
@@ -27,7 +28,8 @@ class Authenticator(object):
         self.redirect_uri = redirect_uri
 
     def _post(self, url, success_status=codes['ok'], **data):
-        auth = (self.client_id, self.client_secret)
+        secret = self.client_secret if self.client_secret is not None else ''
+        auth = (self.client_id, secret)
         response = self._requestor.request('post', url, auth=auth,
                                            data=sorted(data.items()))
         if response.status_code != success_status:
@@ -174,17 +176,17 @@ class DeviceIDAuthorizer(Authorizer):
     due to the lack of an associated reddit account.
     """
 
-    def __init__(self, authenticator, device_id):
+    def __init__(self, authenticator, device_id='DO_NOT_TRACK_THIS_DEVICE'):
         """Represents an app-only OAuth2 authorization for 'installed' apps.
 
         :param authenticator: An instance of :class:`Authenticator`.
-        :param device_id: A unique ID (20-30 character ASCII string)
+        :param device_id: (optional) A unique ID (20-30 character ASCII string)
             For more information about this parameter, see:
             https://github.com/reddit/reddit/wiki/OAuth2#application-only-oauth
         """
-        if authenticator.client_secret != '':
+        if authenticator.client_secret:
             raise InvalidInvocation(
-                'confindential client cannot instantiate this class')
+                'confidential client cannot instantiate this class')
         super(DeviceIDAuthorizer, self).__init__(authenticator)
         self._device_id = device_id
 

--- a/tests/test_authorizer.py
+++ b/tests/test_authorizer.py
@@ -160,6 +160,20 @@ class AuthorizerTest(AuthorizerTestBase):
 class DeviceIDAuthorizerTest(AuthorizerTestBase):
     DEVICE_ID = 'DO_NOT_TRACK_THIS_DEVICE'
 
+    def test_initialize(self):
+        authorizer = prawcore.DeviceIDAuthorizer(self.authentication,
+                                                 self.DEVICE_ID)
+        self.assertIsNone(authorizer.access_token)
+        self.assertIsNone(authorizer.scopes)
+        self.assertIsNone(authorizer.refresh_token)
+        self.assertFalse(authorizer.is_valid())
+
+    def test_initialize__with_client_secret(self):
+        self.authentication.client_secret = 'dummy_client_secret'
+        self.assertRaises(prawcore.InvalidInvocation,
+                          prawcore.DeviceIDAuthorizer,
+                          self.authentication, self.DEVICE_ID)
+
     def test_refresh(self):
         authorizer = prawcore.DeviceIDAuthorizer(self.authentication,
                                                  self.DEVICE_ID)
@@ -176,20 +190,6 @@ class DeviceIDAuthorizerTest(AuthorizerTestBase):
         with Betamax(REQUESTOR).use_cassette(
                  'DeviceIDAuthorizer_refresh__with_short_device_id'):
             self.assertRaises(prawcore.OAuthException, authorizer.refresh)
-
-    def test_initialize(self):
-        authorizer = prawcore.DeviceIDAuthorizer(self.authentication,
-                                                 self.DEVICE_ID)
-        self.assertIsNone(authorizer.access_token)
-        self.assertIsNone(authorizer.scopes)
-        self.assertIsNone(authorizer.refresh_token)
-        self.assertFalse(authorizer.is_valid())
-
-    def test_initialize__with_client_secret(self):
-        self.authentication.client_secret = 'dummy_client_secret'
-        self.assertRaises(prawcore.InvalidInvocation,
-                          prawcore.DeviceIDAuthorizer,
-                          self.authentication, self.DEVICE_ID)
 
 class ReadOnlyAuthorizerTest(AuthorizerTestBase):
     def test_refresh(self):


### PR DESCRIPTION
This feature provides [application-only OAuth2 flow](https://github.com/reddit/reddit/wiki/OAuth2/601b10dc29d443c2b6c0d652bb71e972618117a3) support for 'installed' applicaitons.


## Concerns

All tests passed in my environment with follwoing command:

    $ PRAW_CLIENT_ID=$INSTALLED_CLIENT_ID PRAW_CLIENT_SECRET='' ./pre_push.sh

but output cassetts get garbled with `<CLIENT_SECRET>` place holders.