### PR TITLE
Allow passing custom Session class to Requestor

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,5 @@ Contributors
 ============
 
 - nmtake `@nmtake <https://github.com/nmtake>`_
+- elnuno `@elnuno <https://github.com/elnuno>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Change Log
 prawcore follows `semantic versioning <http://semver.org/>`_ with the exception
 that deprecations will not be announced by a minor release.
 
+Unreleased
+----------
+ 
+**Added**
+
+* Add ``session`` parameter to Requestor to ease support of custom sessions 
+  (e.g. caching or mock ones).
+
 0.8.0 (2017-01-29)
 ------------------
 

--- a/examples/caching_requestor.py
+++ b/examples/caching_requestor.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+"""This example shows how simple in-memory caching can be used.
+
+Demonstrates the use of custom sessions with ``Requestor``. It's an adaptation
+of ``read_only_auth_trophies.py``.
+
+"""
+
+import requests
+import prawcore
+import os
+import sys
+
+
+class CachingSession(requests.Session):
+    """Cache GETs in memory.
+
+    Toy example of custom session to showcase the ``session`` parameter of
+    ``Requestor``.
+    """
+
+    get_cache = {}
+
+    def request(self, method, url, params=None, **kwargs):
+        """Caching version of requests.Session.request."""
+        params_key = tuple(params.items()) if params else ()
+        if method.upper() == 'GET':
+            if (url, params_key) in self.get_cache:
+                print('Returning cached response for:', method, url, params)
+                return self.get_cache[(url, params_key)]
+        result = super().request(method, url, params, **kwargs)
+        if method.upper() == 'GET':
+            self.get_cache[(url, params_key)] = result
+            print('Adding entry to the cache:', method, url, params)
+        return result
+
+
+def main():
+    """Provide the program's entry point when directly executed."""
+    if len(sys.argv) != 2:
+        print('Usage: {} USERNAME'.format(sys.argv[0]))
+        return 1
+
+    caching_requestor = prawcore.Requestor('prawcore_device_id_auth_example',
+                                           session=CachingSession())
+    authenticator = prawcore.TrustedAuthenticator(
+        caching_requestor,
+        os.environ['PRAWCORE_CLIENT_ID'],
+        os.environ['PRAWCORE_CLIENT_SECRET'])
+    authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
+    authorizer.refresh()
+
+    user = sys.argv[1]
+    with prawcore.session(authorizer) as session:
+        data1 = session.request('GET', '/api/v1/user/{}/trophies'.format(user))
+
+    with prawcore.session(authorizer) as session:
+        data2 = session.request('GET', '/api/v1/user/{}/trophies'.format(user))
+
+    for trophy in data1['data']['trophies']:
+        description = trophy['data']['description']
+        print('Original:', trophy['data']['name'] +
+              (' ({})'.format(description) if description else ''))
+
+    for trophy in data2['data']['trophies']:
+        description = trophy['data']['description']
+        print('Cached:', trophy['data']['name'] +
+              (' ({})'.format(description) if description else ''))
+    print('----\nCached == Original:',
+          data2['data']['trophies'] == data2['data']['trophies'])
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -14,7 +14,7 @@ class Requestor(object):
         return getattr(self._http, attribute)
 
     def __init__(self, user_agent, oauth_url='https://oauth.reddit.com',
-                 reddit_url='https://www.reddit.com'):
+                 reddit_url='https://www.reddit.com', session_cls=None):
         """Create an instance of the Requestor class.
 
         :param user_agent: The user-agent for your application. Please follow
@@ -24,12 +24,14 @@ class Requestor(object):
             reddit site. (Default: https://oauth.reddit.com)
         :param reddit_url: (Optional) The URL used when obtaining access
             tokens. (Default: https://www.reddit.com)
-
+        :param session_cls: (Optional) A class to handle requests, compatible
+            with requests.Session. (Default: None)
         """
         if user_agent is None or len(user_agent) < 7:
             raise InvalidInvocation('user_agent is not descriptive')
 
-        self._http = requests.Session()
+        session_cls = session_cls or requests.Session
+        self._http = session_cls()
         self._http.headers['User-Agent'] = '{} prawcore/{}'.format(
             user_agent, __version__)
 

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -14,7 +14,7 @@ class Requestor(object):
         return getattr(self._http, attribute)
 
     def __init__(self, user_agent, oauth_url='https://oauth.reddit.com',
-                 reddit_url='https://www.reddit.com', session_cls=None):
+                 reddit_url='https://www.reddit.com', session=None):
         """Create an instance of the Requestor class.
 
         :param user_agent: The user-agent for your application. Please follow
@@ -24,14 +24,13 @@ class Requestor(object):
             reddit site. (Default: https://oauth.reddit.com)
         :param reddit_url: (Optional) The URL used when obtaining access
             tokens. (Default: https://www.reddit.com)
-        :param session_cls: (Optional) A class to handle requests, compatible
-            with requests.Session. (Default: None)
+        :param session: (Optional) A session to handle requests, compatible
+            with requests.Session(). (Default: None)
         """
         if user_agent is None or len(user_agent) < 7:
             raise InvalidInvocation('user_agent is not descriptive')
 
-        session_cls = session_cls or requests.Session
-        self._http = session_cls()
+        self._http = session or requests.Session()
         self._http.headers['User-Agent'] = '{} prawcore/{}'.format(
             user_agent, __version__)
 

--- a/tests/test_requestor.py
+++ b/tests/test_requestor.py
@@ -3,7 +3,7 @@ import pickle
 
 import prawcore
 import unittest
-from mock import patch
+from mock import patch, Mock
 from prawcore import RequestException
 
 
@@ -33,6 +33,24 @@ class RequestorTest(unittest.TestCase):
                          context_manager.exception.request_args)
         self.assertEqual({'data': 'bar'},
                          context_manager.exception.request_kwargs)
+
+    def test_request__use_custom_session(self):
+        override = 'REQUEST OVERRIDDEN'
+        custom_header = 'CUSTOM SESSION HEADER'
+        headers = {'session_header': custom_header}
+        attrs = {'request.return_value': override, 'headers': headers}
+        session = Mock(**attrs)
+
+        requestor = prawcore.Requestor('prawcore:test (by /u/bboe)',
+                                       session=session)
+
+        self.assertEqual('prawcore:test (by /u/bboe) prawcore/{}'
+                         .format(prawcore.__version__),
+                         requestor._http.headers['User-Agent'])
+        self.assertEqual(requestor._http.headers['session_header'],
+                         custom_header)
+
+        self.assertEqual(requestor.request('https://reddit.com'), override)
 
     def test_pickle(self):
         requestor = prawcore.Requestor('prawcore:test (by /u/bboe)')


### PR DESCRIPTION
I'm using cachecontrol with PRAW and being able to pass a custom Session would eliminate the need to subclass Requestor just to wrap/tinker with the session. 