### PR TITLE
allow Requestor to take in proxies for use with requests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,4 +11,5 @@ Contributors
 
 - nmtake `@nmtake <https://github.com/nmtake>`_
 - elnuno `@elnuno <https://github.com/elnuno>`_
+- Robbie Gibson `@rkgibson2 <https://github.com/rkgibson2>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Change Log
 prawcore follows `semantic versioning <http://semver.org/>`_ with the exception
 that deprecations will not be announced by a minor release.
 
+Unreleased
+----------
+
+**Added**
+* Requestor now accepts keyword argument ``proxies`` to use for all requests.
+
 0.10.1 (2017-04-10)
 -------------------
 

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -14,7 +14,8 @@ class Requestor(object):
         return getattr(self._http, attribute)
 
     def __init__(self, user_agent, oauth_url='https://oauth.reddit.com',
-                 reddit_url='https://www.reddit.com', session=None):
+                 reddit_url='https://www.reddit.com', session=None,
+                 proxies=None):
         """Create an instance of the Requestor class.
 
         :param user_agent: The user-agent for your application. Please follow
@@ -26,11 +27,14 @@ class Requestor(object):
             tokens. (Default: https://www.reddit.com)
         :param session: (Optional) A session to handle requests, compatible
             with requests.Session(). (Default: None)
+        :param proxies: (Optional) A proxies dict to be used by the
+            requests library. PRAW only uses https. (Default: None)
         """
         if user_agent is None or len(user_agent) < 7:
             raise InvalidInvocation('user_agent is not descriptive')
 
         self._http = session or requests.Session()
+        self._http.proxies = proxies
         self._http.headers['User-Agent'] = '{} prawcore/{}'.format(
             user_agent, __version__)
 

--- a/tests/test_requestor.py
+++ b/tests/test_requestor.py
@@ -19,6 +19,12 @@ class RequestorTest(unittest.TestCase):
             self.assertRaises(prawcore.InvalidInvocation, prawcore.Requestor,
                               agent)
 
+    def test_initialize__proxies(self):
+        expectedProxies = {'https': 'http://www.example.com'}
+        requestor = prawcore.Requestor('prawcore:test (by /u/bboe)',
+                                       proxies=expectedProxies)
+        self.assertEqual(requestor._http.proxies, expectedProxies)
+
     @patch('requests.Session')
     def test_request__wrap_request_exceptions(self, mock_session):
         exception = Exception('prawcore wrap_request_exceptions')


### PR DESCRIPTION
It looks like this functionality was added in praw-dev/praw#317, but removed somewhere along the way. In `praw`, the `https_proxy` variable is still being read from `praw.ini`, so I assumed it was still something desirable. I also have a pull request in `praw` for the changes there.