### PR TITLE
Add SpecialError to handle HTTP 415.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,4 +12,5 @@ Contributors
 - nmtake `@nmtake <https://github.com/nmtake>`_
 - elnuno `@elnuno <https://github.com/elnuno>`_
 - Zeerak Waseem <zeerak.w@gmail.com> `@ZeerakW <https://github.com/ZeerakW>`_
+- jarhill0 `@jarhill0 <https://github.com/jarhill0>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Change Log
 prawcore follows `semantic versioning <http://semver.org/>`_ with the exception
 that deprecations will not be announced by a minor release.
 
+Unreleased
+----------
+
+**Added**
+
+``SpecialError`` is raised on HTTP 415.
+
 0.14.0 (2018-02-10)
 -------------------
 

--- a/prawcore/exceptions.py
+++ b/prawcore/exceptions.py
@@ -106,7 +106,7 @@ class Redirect(ResponseException):
     """
 
     def __init__(self, response):
-        """Initialize a Redirect exception instance..
+        """Initialize a Redirect exception instance.
 
         :param response: A requests.response instance containing a location
         header.
@@ -120,6 +120,26 @@ class Redirect(ResponseException):
 
 class ServerError(ResponseException):
     """Indicate issues on the server end preventing request fulfillment."""
+
+
+class SpecialError(ResponseException):
+    """Indicate syntax or spam-prevention issues."""
+
+    def __init__(self, response):
+        """Initialize a SpecialError exception instance.
+
+        :param response: A requests.response instance containing a message
+        and a list of special errors.
+
+        """
+        self.response = response
+
+        resp_dict = self.response.json()  # assumes valid JSON
+        self.message = resp_dict.get('message', '')
+        self.reason = resp_dict.get('reason', '')
+        self.special_errors = resp_dict.get('special_errors', [])
+        PrawcoreException.__init__(self, 'Special error {!r}'.format(
+            self.message))
 
 
 class TooLarge(ResponseException):

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -13,7 +13,7 @@ from .auth import BaseAuthorizer
 from .rate_limit import RateLimiter
 from .exceptions import (BadJSON, BadRequest, Conflict, InvalidInvocation,
                          NotFound, Redirect, RequestException, ServerError,
-                         TooLarge, UnavailableForLegalReasons)
+                         SpecialError, TooLarge, UnavailableForLegalReasons)
 from .util import authorization_error_class
 
 log = logging.getLogger(__package__)
@@ -33,6 +33,7 @@ class Session(object):
                          codes['forbidden']: authorization_error_class,
                          codes['gateway_timeout']: ServerError,
                          codes['internal_server_error']: ServerError,
+                         codes['media_type']: SpecialError,
                          codes['not_found']: NotFound,
                          codes['request_entity_too_large']: TooLarge,
                          codes['service_unavailable']: ServerError,

--- a/tests/cassettes/Session_request__unsupported_media_type.json
+++ b/tests/cassettes/Session_request__unsupported_media_type.json
@@ -1,0 +1,230 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-03-17T04:29:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "53"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "loid=mmMAwMoHaJm04NKk1i; session_tracker=DJojrrAVPFxgb0vizI.0.1495932294853.Z0FBQUFBQlpLaDJIaFl0OUFYbXdtejdaSmg3Mm5ZZ19EZ2JzTzZhVlFEbERZUVZ2RzJuOUpVWkUwQVBQUmRBLWpZWUVEaHBzNy1nTEh1LXN3TVZHa1dwNDJ1ai05cko1OWhWRDVFLWw2MEN5VEdmNTdHejZUcFJwWUhiUWtmSS1nY2czaklKanNoTVY"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/0.14.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"0oMQ0UR6qTnRWidnH1mbXrIgucQ\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "105"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 17 Mar 2018 04:29:33 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-sjc3637-SJC"
+          ],
+          "X-Timer": [
+            "S1521260973.107432,VS0,VE452"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "set-cookie": [
+            "session_tracker=jfaburHovD9fuehUDX.0.1521260973148.Z0FBQUFBQmFySm10aU42amkyM2RrcDc3WFZFcTNNdW5UZ0FfMXlfM2tIZ2dSVkZRODV6aHFUbjJVRHZyWmh1V1UxQUtRQTA3dVd1RWJhaXdMdDZrV2hVNG96YWZ2VTRaMlB4dEcwLV9qQndlX3NLZWNjOG9xYTBaRmdtLWVJUnptdExxSjhuMmNabFY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 17-Mar-2018 06:29:33 GMT; secure",
+            "edgebucket=9oc0rjaOoD6kfWnzW7; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-03-17T04:29:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&content=type%3A+submission%0Aaction%3A+upvote&page=config%2Fautomoderator"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer oNOjYO9S4zSVLw3pG7o62C1FKec"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "87"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=9oc0rjaOoD6kfWnzW7; loid=mmMAwMoHaJm04NKk1i; session_tracker=jfaburHovD9fuehUDX.0.1521260973148.Z0FBQUFBQmFySm10aU42amkyM2RrcDc3WFZFcTNNdW5UZ0FfMXlfM2tIZ2dSVkZRODV6aHFUbjJVRHZyWmh1V1UxQUtRQTA3dVd1RWJhaXdMdDZrV2hVNG96YWZ2VTRaMlB4dEcwLV9qQndlX3NLZWNjOG9xYTBaRmdtLWVJUnptdExxSjhuMmNabFY"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/0.14.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/ttft/api/wiki/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"reason\": \"SPECIAL_ERRORS\", \"message\": \"Unsupported Media Type\", \"special_errors\": [\"invalid value for `action`: `upvote` in rule:\\n\\ntype: submission\\naction: upvote\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "170"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 17 Mar 2018 04:29:33 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-pao17425-PAO"
+          ],
+          "X-Timer": [
+            "S1521260974.687912,VS0,VE115"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "loid=0000000000014g6bq9.2.1494785872695.Z0FBQUFBQmFySm10THNuVnRIVVZjNHFtWERwcGc1UXdKa0hQZGhyNmlDUV80dDBSUHVpZDU4UW5rWlMxQW1KenV3WlhtUGlNZHJIbWEtVTJuMU1CS1gxRmQxSFhPa1dxdnNGMVo3QUJUM2Y1YlVkRFNyeUlzV2dNNUN3UFNwdkFmOEMtM0xkYjhhTGM; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 16-Mar-2020 04:29:33 GMT; secure",
+            "session_tracker=jfaburHovD9fuehUDX.0.1521260973725.Z0FBQUFBQmFySm10RU1INVVwODZsQWM0UXZwZXI1ajZLMWo1cUJiZ1RWRUtXZ1h4RkxtVlBNSlByUlRKTGUxYTZBV1lkRWhYcTl1WTNBZllvWnJBSzdpcF9xNDNPTTMxUXAwV19oLXZCYTNYMHgwa0pIMjA3UkFnRDd1czhxVTBkaUpkVmg5SElxNVg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 17-Mar-2018 06:29:33 GMT; secure",
+            "loid_old=mmMAwMoHaJm04NKk1i; Domain=reddit.com; Max-Age=5183999; Path=/; expires=Wed, 16-May-2018 04:29:33 GMT; secure",
+            "loid=000000000011xj3ttp.2.1521260973762.Z0FBQUFBQmFySm10U1JHUHVJMlFuSWNNSkFyYTU3WVZZYm0xZmxzLUlCa1BmcDJBcF9vQVFIeXZ2dVNJdXB4U18wSmttZGpyaU1ib3dtekV3ZEVKS0FTLW44MF9WNE5KbjBvUXNLdFZUdGp0aGtVajZGSk54Qll4WkF3b0xfNkFLZkI3ZzdUUVVYWGE; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 16-Mar-2020 04:29:33 GMT; secure",
+            "session_tracker=jfaburHovD9fuehUDX.0.1521260973759.Z0FBQUFBQmFySm10X2dFTEtiMmtKY1E1N1ZJZTEzdEdRa0gtOGhKeElxRlFYV2FObnA1Y2RQWVpsQUREY0dLN3doY09GQ3dsYWhtTkxOYjAyNUstT0dBT21XcVlGaE1jRnRMUTI4UmJpSkwtdWdvNHNxS1EwOWV2dDlxQXdEVzVjT2hkT3drTjVJY3Y; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 17-Mar-2018 06:29:33 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "597.0"
+          ],
+          "x-ratelimit-reset": [
+            "27"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 415,
+          "message": "Unsupported Media Type"
+        },
+        "url": "https://oauth.reddit.com/r/ttft/api/wiki/edit/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -361,6 +361,19 @@ class SessionTest(unittest.TestCase):
             self.assertEqual(
                 451, context_manager.exception.response.status_code)
 
+    def test_request__unsupported_media_type(self):
+        with Betamax(REQUESTOR).use_cassette(
+                'Session_request__unsupported_media_type'):
+            session = prawcore.Session(script_authorizer())
+            exception_class = prawcore.SpecialError
+            data = {'content': 'type: submission\naction: upvote',
+                    'page': 'config/automoderator'}
+            with self.assertRaises(exception_class) as context_manager:
+                session.request('POST', 'r/ttft/api/wiki/edit/',
+                                data=data)
+            self.assertEqual(415,
+                             context_manager.exception.response.status_code)
+
     def test_request__with_insufficent_scope(self):
         with Betamax(REQUESTOR).use_cassette(
                 'Session_request__with_insufficient_scope'):


### PR DESCRIPTION
Fixes #65.

This adds class `SpecialError`. When raised, it uses the `message` field from the response in the text of the exception. `message`, `reason`, and `special_errors` are all saved on the `SpecialError` object.