### PR TITLE
Don't allow RateLimiter to wait longer than next request timestamp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Change Log
 prawcore follows `semantic versioning <http://semver.org/>`_ with the exception
 that deprecations will not be announced by a minor release.
 
+1.0.1 (2019-02-05)
+------------------
+
+**Fixed**
+
+* ``RateLimiter`` will not sleep longer than ``next_request_timestamp``.
+
 1.0.0 (2018-04-26)
 ------------------
 

--- a/prawcore/const.py
+++ b/prawcore/const.py
@@ -1,7 +1,7 @@
 """Constants for the prawcore package."""
 import os
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 ACCESS_TOKEN_PATH = '/api/v1/access_token'
 AUTHORIZATION_PATH = '/api/v1/authorize'

--- a/prawcore/rate_limit.py
+++ b/prawcore/rate_limit.py
@@ -82,5 +82,5 @@ class RateLimiter(object):
         else:
             estimated_clients = 1.0
 
-        self.next_request_timestamp = now + (
-            estimated_clients * seconds_to_reset / self.remaining)
+        self.next_request_timestamp = min(self.reset_timestamp, now + (
+            estimated_clients * seconds_to_reset / self.remaining))


### PR DESCRIPTION
There's some discussion about this issue here: https://www.reddit.com/r/redditdev/comments/ajmy2t/praw_long_sleep/eezw2ke/