### PR TITLE
Unpin mock dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "betamax >=0.8, <0.9",
         "betamax_matchers >=0.4.0, <0.5",
         "betamax-serializers >=0.2.0, <0.3",
-        "mock >=0.8, <3",
+        "mock >=0.8",
         "testfixtures >4.13.2, <7",
     ],
     test_suite="tests",


### PR DESCRIPTION
mock is unpinned in praw:setup.py:tests_require ("mock >=0.8",)

Unpin it here to match, allowing mock 3.x to satisfy the dependency.

Testing with latest upstream sources allows us to pick up incompatibilities sooner and reduces friction for downstream packages who generally use system provided packages (including tests_requires) to QA, and who's clean-room QA systems generally don't allow network connectivity during builds/QA/packaging, which precludes fetching dependencies from remote sources.

Tests for prawcore 1.0.1 sdist pass with mock 3.0.4 (latest at the time of writing)

Ran 90 tests in 1.662s OK