### PR TITLE
Rate limit

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,4 +13,5 @@ Contributors
 - elnuno `@elnuno <https://github.com/elnuno>`_
 - Zeerak Waseem <zeerak.w@gmail.com> `@ZeerakW <https://github.com/ZeerakW>`_
 - jarhill0 `@jarhill0 <https://github.com/jarhill0>`_
+- Watchful1 `@Watchful1 <https://github.com/Watchful1>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ that deprecations will not be announced by a minor release.
 Unreleased
 ----------
 
+**Changed**
+
+* Updated rate limit algorithm to more intelligently rate limit when there
+  are extra requests remaining.
+
 **Removed**
 
 * Drop python 2.7 support.

--- a/prawcore/rate_limit.py
+++ b/prawcore/rate_limit.py
@@ -67,7 +67,6 @@ class RateLimiter(object):
             return
 
         now = time.time()
-        prev_remaining = self.remaining
 
         seconds_to_reset = int(response_headers["x-ratelimit-reset"])
         self.remaining = float(response_headers["x-ratelimit-remaining"])
@@ -78,12 +77,7 @@ class RateLimiter(object):
             self.next_request_timestamp = self.reset_timestamp
             return
 
-        if prev_remaining is not None and prev_remaining > self.remaining:
-            estimated_clients = prev_remaining - self.remaining
-        else:
-            estimated_clients = 1.0
-
         self.next_request_timestamp = min(
             self.reset_timestamp,
-            now + (estimated_clients * seconds_to_reset / self.remaining),
+            now + max(min((seconds_to_reset - self.remaining) / 2, 10), 0),
         )

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -70,22 +70,22 @@ class RateLimiterTest(unittest.TestCase):
         self.rate_limiter.update(self._headers(60, 100, 60))
         self.assertEqual(60, self.rate_limiter.remaining)
         self.assertEqual(100, self.rate_limiter.used)
-        self.assertEqual(101, self.rate_limiter.next_request_timestamp)
+        self.assertEqual(100, self.rate_limiter.next_request_timestamp)
 
     @patch("time.time")
     def test_update__compute_delay_with_single_client(self, mock_time):
         self.rate_limiter.remaining = 61
         mock_time.return_value = 100
-        self.rate_limiter.update(self._headers(60, 100, 60))
-        self.assertEqual(60, self.rate_limiter.remaining)
+        self.rate_limiter.update(self._headers(50, 100, 60))
+        self.assertEqual(50, self.rate_limiter.remaining)
         self.assertEqual(100, self.rate_limiter.used)
-        self.assertEqual(101, self.rate_limiter.next_request_timestamp)
+        self.assertEqual(105, self.rate_limiter.next_request_timestamp)
 
     @patch("time.time")
     def test_update__compute_delay_with_six_clients(self, mock_time):
         self.rate_limiter.remaining = 66
         mock_time.return_value = 100
-        self.rate_limiter.update(self._headers(60, 100, 60))
+        self.rate_limiter.update(self._headers(60, 100, 72))
         self.assertEqual(60, self.rate_limiter.remaining)
         self.assertEqual(100, self.rate_limiter.used)
         self.assertEqual(106, self.rate_limiter.next_request_timestamp)


### PR DESCRIPTION
Closes #89 

Unit tests for this was tricky, since the new formula dynamically calculates the correct delay over several requests, rather than just the first one. But I updated the tests as best I could.