### PR TITLE
Fix minor typo in AUTHORS.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,5 +14,5 @@ Contributors
 - Zeerak Waseem <zeerak.w@gmail.com> `@ZeerakW <https://github.com/ZeerakW>`_
 - jarhill0 `@jarhill0 <https://github.com/jarhill0>`_
 - Watchful1 `@Watchful1 <https://github.com/Watchful1>`_
-- PythonCoderAS `@PythonCoderAS <https://github.com/PythonCoderAS?`_
+- PythonCoderAS `@PythonCoderAS <https://github.com/PythonCoderAS>`_
 - Add "Name <email (optional)> and github profile link" above this line.


### PR DESCRIPTION
I accidentally used `?` instead of `>`. 