### PR TITLE
Fail on attempting to install on python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     description="Low-level communication layer for PRAW 4+.",
     extras_require=extras,
     install_requires=["requests >=2.6.0, <3.0"],
+    python_requires=">=3.5,<4",
     keywords="praw reddit api",
     license="Simplified BSD License",
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     description="Low-level communication layer for PRAW 4+.",
     extras_require=extras,
     install_requires=["requests >=2.6.0, <3.0"],
-    python_requires=">=3.5,<4",
+    python_requires=">=3.5",
     keywords="praw reddit api",
     license="Simplified BSD License",
     long_description=README,


### PR DESCRIPTION
no longer compatible with python2's urllib

```
  ...
  prawcore/exceptions.py:2: in <module>
      from urllib.parse import urlparse
  E   ImportError: No module named parse
  builder for '/nix/store/3l1rqygq58hbwyzn6fqx8x4djbmzgggh-python2.7-prawcore-1.4.0.drv' failed with exit code 4
```