### PR TITLE
Require python 3.6 properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     description="Low-level communication layer for PRAW 4+.",
     extras_require=extras,
     install_requires=["requests >=2.6.0, <3.0"],
-    python_requires=">=3.5",
+    python_requires="~=3.6",
     keywords="praw reddit api",
     license="Simplified BSD License",
     long_description=README,


### PR DESCRIPTION
`>=3.5` still supports 3.5.