### PR TITLE
Reformat to 88 and code/documentation cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[lint]
+    - name: Run flynt
+      run: flynt -vdf -tc -ll 1000 .
     - name: Run black
       run: black --check --verbose .
     - name: Run flake8

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,4 +14,5 @@ Contributors
 - jarhill0 `@jarhill0 <https://github.com/jarhill0>`_
 - Watchful1 `@Watchful1 <https://github.com/Watchful1>`_
 - PythonCoderAS `@PythonCoderAS <https://github.com/PythonCoderAS>`_
+- LilSpazJoekp `@LilSpazJoekp <https://github.com/LilSpazJoekp>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,7 +5,6 @@ Maintainers
 
 - Bryce Boe <bbzbryce@gmail.com> `@bboe <https://github.com/bboe>`_
 
-
 Contributors
 ============
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,164 +1,159 @@
 Change Log
 ==========
 
-prawcore follows `semantic versioning <http://semver.org/>`_ with the exception
-that deprecations will not be announced by a minor release.
+prawcore follows `semantic versioning <http://semver.org/>`_ with the exception that
+deprecations will not be announced by a minor release.
 
 1.5.0 (2020-08-04)
 ------------------
 
 **Changed**
 
-* Drop support for Python 3.5, which is end-of-life on 2020-09-13.
+- Drop support for Python 3.5, which is end-of-life on 2020-09-13.
 
 1.4.0 (2020-05-28)
 ------------------
 
 **Added**
 
-* When calling :meth:`.Session.request`, we add the key-value pair
-  ``"api_type": "json"`` to the ``json`` parameter, if it is a ``dict``.
+- When calling :meth:`.Session.request`, we add the key-value pair ``"api_type":
+  "json"`` to the ``json`` parameter, if it is a ``dict``.
 
 **Changed**
 
-* (Non-breaking) Requests to ``www.reddit.com`` use the ``Connection: close``
-  header to avoid warnings when tokens are refreshed after their one-hour
-  expiration.
-
+- (Non-breaking) Requests to ``www.reddit.com`` use the ``Connection: close`` header to
+  avoid warnings when tokens are refreshed after their one-hour expiration.
 
 1.3.0 (2020-04-23)
 ------------------
 
 **Added**
 
-* All other requestor methods, most notably :meth:`.Session.request`, now contain
-  a ``timeout`` parameter.
-
+- All other requestor methods, most notably :meth:`.Session.request`, now contain a
+  ``timeout`` parameter.
 
 1.2.0 (2020-04-23)
 ------------------
 
 **Added**
 
-* Method ``Requestor.request`` can be given a timeout parameter to 
-  control the amount of time to wait for a request to succeed.
+- Method ``Requestor.request`` can be given a timeout parameter to control the amount of
+  time to wait for a request to succeed.
 
 **Changed**
 
-* Updated rate limit algorithm to more intelligently rate limit when there
-  are extra requests remaining.
+- Updated rate limit algorithm to more intelligently rate limit when there are extra
+  requests remaining.
 
 **Removed**
 
-* Drop python 2.7 support.
+- Drop python 2.7 support.
 
 1.0.1 (2019-02-05)
 ------------------
 
 **Fixed**
 
-* ``RateLimiter`` will not sleep longer than ``next_request_timestamp``.
+- ``RateLimiter`` will not sleep longer than ``next_request_timestamp``.
 
 1.0.0 (2018-04-26)
 ------------------
 
-I am releasing 1.0.0 as prawcore is quite stable and it's unlikely that any
-breaking changes will need to be introduced in the near future.
+I am releasing 1.0.0 as prawcore is quite stable and it's unlikely that any breaking
+changes will need to be introduced in the near future.
 
 **Added**
 
-* Log debug messages for all sleep times.
+- Log debug messages for all sleep times.
 
 0.15.0 (2018-03-31)
 -------------------
 
 **Added**
 
-* ``SpecialError`` is raised on HTTP 415.
+- ``SpecialError`` is raised on HTTP 415.
 
 0.14.0 (2018-02-10)
 -------------------
 
 **Added**
 
-* ``ReadTimeout`` is automatically retried like the server errors.
+- ``ReadTimeout`` is automatically retried like the server errors.
 
 **Removed**
 
-* Removed support for Python 3.3 as it is no longer supported by requests.
+- Removed support for Python 3.3 as it is no longer supported by requests.
 
 0.13.0 (2017-12-16)
 -------------------
 
 **Added**
 
-* ``UnavailableForLegalReasons`` exception raised when HTTP Response 451 is
-  encountered.
+- ``UnavailableForLegalReasons`` exception raised when HTTP Response 451 is encountered.
 
 0.12.0 (2017-08-30)
 -------------------
 
 **Added**
 
-* ``BadJSON`` exception for the rare cases that a response that should contain
-  valid JSON has unparsable JSON.
+- ``BadJSON`` exception for the rare cases that a response that should contain valid
+  JSON has unparsable JSON.
 
 0.11.0 (2017-05-27)
 -------------------
 
 **Added**
 
-* ``Conflict`` exception is raised when response status 409 is returned.
+- ``Conflict`` exception is raised when response status 409 is returned.
 
 0.10.1 (2017-04-10)
 -------------------
 
 **Fixed**
 
-* ``InvalidToken`` is again raised on 401 when a non-refreshable application is
-  in use.
+- ``InvalidToken`` is again raised on 401 when a non-refreshable application is in use.
 
 0.10.0 (2017-04-10)
 -------------------
 
 **Added**
 
-* ``ConnectionError`` exceptions are automatically retried. This handles
-  ``Connection Reset by Peer`` issues that appear to occur somewhat frequently
-  when running on Amazon EC2.
+- ``ConnectionError`` exceptions are automatically retried. This handles ``Connection
+  Reset by Peer`` issues that appear to occur somewhat frequently when running on Amazon
+  EC2.
 
 **Changed**
 
-* Calling ``RateLimiter`` now requires a second positional argument,
+- Calling ``RateLimiter`` now requires a second positional argument,
   ``set_header_callback``.
-* In the event a 401 unauthorized occurs, the access token is cleared and the
-  request is retried.
+- In the event a 401 unauthorized occurs, the access token is cleared and the request is
+  retried.
 
 **Fixed**
 
-* Check if the access token is expired immediately before every authorized
-  request, rather than just before the request flow. This new approach accounts
-  for failure retries, and rate limiter delay.
+- Check if the access token is expired immediately before every authorized request,
+  rather than just before the request flow. This new approach accounts for failure
+  retries, and rate limiter delay.
 
 0.9.0 (2017-03-11)
 ------------------
 
 **Added**
 
-* Add ``session`` parameter to Requestor to ease support of custom sessions
-  (e.g. caching or mock ones).
+- Add ``session`` parameter to Requestor to ease support of custom sessions (e.g.
+  caching or mock ones).
 
 0.8.0 (2017-01-29)
 ------------------
 
 **Added**
 
-* Handle 413 Request entity too large responses.
-* ``reset_timestamp`` to ``RateLimiter``.
+- Handle 413 Request entity too large responses.
+- ``reset_timestamp`` to ``RateLimiter``.
 
 **Fixed**
 
-* Avoid modifying passed in ``data`` and ``params`` to ``Session.request``.
+- Avoid modifying passed in ``data`` and ``params`` to ``Session.request``.
 
 0.7.0 (2017-01-16)
 ------------------
@@ -172,107 +167,102 @@ breaking changes will need to be introduced in the near future.
 
 **Added**
 
-* Handle 500 responses.
-* Handle Cloudflare 520 responses.
-
+- Handle 500 responses.
+- Handle Cloudflare 520 responses.
 
 0.5.0 (2016-12-13)
 ------------------
 
 **Added**
 
-All network requests now have a 16 second timeout by default. The environment
-variable ``prawcore_timeout`` can be used to adjust the value.
+All network requests now have a 16 second timeout by default. The environment variable
+``prawcore_timeout`` can be used to adjust the value.
 
 0.4.0 (2016-12-09)
 ------------------
 
 **Changed**
 
-* Prevent '(None)' from appearing in OAuthException message.
+- Prevent '(None)' from appearing in OAuthException message.
 
 0.3.0 (2016-11-20)
 ------------------
 
 **Added**
 
-* Add ``files`` parameter to ``Session.request`` to support image upload
-  operations.
-* Add ``duration`` and ``implicit`` parameters to
-  ``UntrustedAuthenticator.authorization_url`` so that the method also supports
-  the code grant flow.
+- Add ``files`` parameter to ``Session.request`` to support image upload operations.
+- Add ``duration`` and ``implicit`` parameters to
+  ``UntrustedAuthenticator.authorization_url`` so that the method also supports the code
+  grant flow.
 
 **Fixed**
 
-* ``Authorizer`` class can be used with ``UntrustedAuthenticator``.
+- ``Authorizer`` class can be used with ``UntrustedAuthenticator``.
 
 0.2.1 (2016-08-07)
 ------------------
 
 **Fixed**
 
-* ``session`` works with ``DeviceIDAuthorizer`` and ``ImplicitAuthorizer``.
-
+- ``session`` works with ``DeviceIDAuthorizer`` and ``ImplicitAuthorizer``.
 
 0.2.0 (2016-08-07)
 ------------------
 
 **Added**
 
-* Add ``ImplicitAuthorizer``.
+- Add ``ImplicitAuthorizer``.
 
 **Changed**
 
-* Split ``Authenticator`` into ``TrustedAuthenticator`` and
-  ``UntrustedAuthenticator``.
+- Split ``Authenticator`` into ``TrustedAuthenticator`` and ``UntrustedAuthenticator``.
 
 0.1.1 (2016-08-06)
 ------------------
 
 **Added**
 
-* Add ``DeviceIDAuthorizer`` that permits installed application access to the
-  API.
+- Add ``DeviceIDAuthorizer`` that permits installed application access to the API.
 
 0.1.0 (2016-08-05)
 ------------------
 
 **Added**
 
-* ``RequestException`` which wraps all exceptions that occur from
-  ``requests.request`` in a ``prawcore.RequestException``.
+- ``RequestException`` which wraps all exceptions that occur from ``requests.request``
+  in a ``prawcore.RequestException``.
 
 **Changed**
 
-* What was previously ``RequestException`` is now ``ResponseException``.
+- What was previously ``RequestException`` is now ``ResponseException``.
 
 0.0.15 (2016-08-02)
 -------------------
 
 **Added**
 
-* Handle Cloudflare 522 responses.
+- Handle Cloudflare 522 responses.
 
 0.0.14 (2016-07-25)
 -------------------
 
 **Added**
 
-* Add ``ServerError`` exception for 502, 503, and 504 HTTP status codes that is
-  only raised after three failed attempts to make the request.
-* Add ``json`` parameter to ``Session.request``.
+- Add ``ServerError`` exception for 502, 503, and 504 HTTP status codes that is only
+  raised after three failed attempts to make the request.
+- Add ``json`` parameter to ``Session.request``.
 
 0.0.13 (2016-07-24)
 -------------------
 
 **Added**
 
-* Automatically attempt to refresh access tokens when making a request if the
-  access token is expired.
+- Automatically attempt to refresh access tokens when making a request if the access
+  token is expired.
 
 **Fixed**
 
-* Consider access tokens expired slightly earlier than allowed for to prevent
+- Consider access tokens expired slightly earlier than allowed for to prevent
   InvalidToken exceptions from occuring.
 
 0.0.12 (2016-07-17)
@@ -280,70 +270,67 @@ variable ``prawcore_timeout`` can be used to adjust the value.
 
 **Added**
 
-* Handle 0-byte HTTP 200 responses.
+- Handle 0-byte HTTP 200 responses.
 
 0.0.11 (2016-07-16)
 -------------------
 
 **Added**
 
-* Add a ``NotFound`` exception.
-* Support 404 "Not Found" HTTP responses.
-
+- Add a ``NotFound`` exception.
+- Support 404 "Not Found" HTTP responses.
 
 0.0.10 (2016-07-10)
 -------------------
 
 **Added**
 
-* Add a ``BadRequest`` exception.
-* Support 400 "Bad Request" HTTP responses.
-* Support 204 "No Content" HTTP responses.
+- Add a ``BadRequest`` exception.
+- Support 400 "Bad Request" HTTP responses.
+- Support 204 "No Content" HTTP responses.
 
 0.0.9 (2016-07-09)
 ------------------
 
 **Added**
 
-* Support 201 "Created" HTTP responses used in some v1 endpoints.
-
+- Support 201 "Created" HTTP responses used in some v1 endpoints.
 
 0.0.8 (2016-03-21)
 ------------------
 
 **Added**
 
-* Sort ``Session.request`` ``data`` values. Sorting the values permits betamax
-  body matcher to work as expected.
-
+- Sort ``Session.request`` ``data`` values. Sorting the values permits betamax body
+  matcher to work as expected.
 
 0.0.7 (2016-03-18)
 ------------------
 
 **Added**
 
-* Added ``data`` parameter to ``Session.request``.
+- Added ``data`` parameter to ``Session.request``.
 
 0.0.6 (2016-03-14)
 ------------------
 
 **Fixed**
 
-* prawcore objects can be pickled.
+- prawcore objects can be pickled.
 
 0.0.5 (2016-03-12)
 ------------------
 
 **Added**
 
-* 302 redirects result in a ``Redirect`` exception.
+- 302 redirects result in a ``Redirect`` exception.
 
 0.0.4 (2016-03-12)
 ------------------
 
 **Added**
 
-* Add a generic ``Forbidden`` exception for 403 responses without the
+- Add a generic ``Forbidden`` exception for 403 responses without the
   ``www-authenticate`` header.
 
 0.0.3 (2016-02-29)
@@ -351,25 +338,25 @@ variable ``prawcore_timeout`` can be used to adjust the value.
 
 **Added**
 
-* Added ``params`` parameter to ``Session.request``.
-* Log requests to the ``prawcore`` logger in debug mode.
+- Added ``params`` parameter to ``Session.request``.
+- Log requests to the ``prawcore`` logger in debug mode.
 
 0.0.2 (2016-02-21)
 ------------------
 
 **Fixed**
 
-* README.rst for display purposes on pypi.
+- README.rst for display purposes on pypi.
 
 0.0.1 (2016-02-17) [YANKED]
 ---------------------------
 
 **Added**
 
-* Dynamic rate limiting based on reddit's response headers.
-* Authorization URL generation.
-* Retrieval of access and refresh tokens from authorization grants.
-* Access and refresh token revocation.
-* Retrieval of read-only access tokens.
-* Retrieval of script-app tokens.
-* Three examples in the ``examples/`` directory.
+- Dynamic rate limiting based on reddit's response headers.
+- Authorization URL generation.
+- Retrieval of access and refresh tokens from authorization grants.
+- Access and refresh token revocation.
+- Retrieval of read-only access tokens.
+- Retrieval of script-app tokens.
+- Three examples in the ``examples/`` directory.

--- a/README.rst
+++ b/README.rst
@@ -4,15 +4,16 @@ prawcore
 ========
 
 .. image:: https://img.shields.io/pypi/v/prawcore.svg
-           :alt: Latest prawcore Version
-           :target: https://pypi.python.org/pypi/prawcore
+    :alt: Latest prawcore Version
+    :target: https://pypi.python.org/pypi/prawcore
+
 .. image:: https://travis-ci.org/praw-dev/prawcore.svg?branch=master
-           :target: https://travis-ci.org/praw-dev/prawcore
+    :target: https://travis-ci.org/praw-dev/prawcore
+
 .. image:: https://coveralls.io/repos/github/praw-dev/prawcore/badge.svg?branch=master
-           :target: https://coveralls.io/github/praw-dev/prawcore?branch=master
+    :target: https://coveralls.io/github/praw-dev/prawcore?branch=master
 
 prawcore is a low-level communication layer used by PRAW 4+.
-
 
 Installation
 ------------
@@ -23,51 +24,49 @@ Install prawcore using ``pip`` via:
 
     pip install prawcore
 
-
 Execution Example
 -----------------
 
-The following example demonstrates how to use prawcore to obtain the list of
-trophies for a given user using the script-app type.  This example assumes you
-have the environment variables ``PRAWCORE_CLIENT_ID`` and
-``PRAWCORE_CLIENT_SECRET`` set to the appropriate values for your application.
+The following example demonstrates how to use prawcore to obtain the list of trophies
+for a given user using the script-app type. This example assumes you have the
+environment variables ``PRAWCORE_CLIENT_ID`` and ``PRAWCORE_CLIENT_SECRET`` set to the
+appropriate values for your application.
 
 .. code-block:: python
 
-   #!/usr/bin/env python
-   import os
-   import pprint
-   import prawcore
+    #!/usr/bin/env python
+    import os
+    import pprint
+    import prawcore
 
-   authenticator = prawcore.TrustedAuthenticator(
-       prawcore.Requestor('YOUR_VALID_USER_AGENT'),
-       os.environ['PRAWCORE_CLIENT_ID'],
-       os.environ['PRAWCORE_CLIENT_SECRET'])
-   authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
-   authorizer.refresh()
+    authenticator = prawcore.TrustedAuthenticator(
+        prawcore.Requestor("YOUR_VALID_USER_AGENT"),
+        os.environ["PRAWCORE_CLIENT_ID"],
+        os.environ["PRAWCORE_CLIENT_SECRET"],
+    )
+    authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
+    authorizer.refresh()
 
-   with prawcore.session(authorizer) as session:
-       pprint.pprint(session.request('GET', '/api/v1/user/bboe/trophies'))
+    with prawcore.session(authorizer) as session:
+        pprint.pprint(session.request("GET", "/api/v1/user/bboe/trophies"))
 
 Save the above as ``trophies.py`` and then execute via:
 
 .. code-block:: console
 
-   python trophies.py
+    python trophies.py
 
 Additional examples can be found at:
 https://github.com/praw-dev/prawcore/tree/master/examples
 
-
 Depending on prawcore
 ---------------------
 
-prawcore follows `semantic versioning <http://semver.org/>`_ with the exception
-that deprecations will not be preceded by a minor release. In essense, expect
-only major versions to introduce breaking changes to prawcore's public
-interface. As a result, if you depend on prawcore then it is a good idea to
-specify not only the minimum version of prawcore your package requires, but to
-also limit the major version.
+prawcore follows `semantic versioning <http://semver.org/>`_ with the exception that
+deprecations will not be preceded by a minor release. In essense, expect only major
+versions to introduce breaking changes to prawcore's public interface. As a result, if
+you depend on prawcore then it is a good idea to specify not only the minimum version of
+prawcore your package requires, but to also limit the major version.
 
 Below are two examples of how you may want to specify your prawcore dependency:
 
@@ -76,13 +75,11 @@ setup.py
 
 .. code-block:: python
 
-   setup(...,
-         install_requires=['prawcore >=0.1, <1'],
-         ...)
+    setup(..., install_requires=["prawcore >=0.1, <1"], ...)
 
 requirements.txt
 ~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
-   prawcore >=1.5.1, <2
+    prawcore >=1.5.1, <2

--- a/examples/caching_requestor.py
+++ b/examples/caching_requestor.py
@@ -7,10 +7,12 @@ of ``read_only_auth_trophies.py``.
 
 """
 
-import requests
-import prawcore
 import os
 import sys
+
+import requests
+
+import prawcore
 
 
 class CachingSession(requests.Session):

--- a/examples/caching_requestor.py
+++ b/examples/caching_requestor.py
@@ -39,7 +39,7 @@ class CachingSession(requests.Session):
 def main():
     """Provide the program's entry point when directly executed."""
     if len(sys.argv) != 2:
-        print("Usage: {} USERNAME".format(sys.argv[0]))
+        print(f"Usage: {sys.argv[0]} USERNAME")
         return 1
 
     caching_requestor = prawcore.Requestor(
@@ -55,17 +55,17 @@ def main():
 
     user = sys.argv[1]
     with prawcore.session(authorizer) as session:
-        data1 = session.request("GET", "/api/v1/user/{}/trophies".format(user))
+        data1 = session.request("GET", f"/api/v1/user/{user}/trophies")
 
     with prawcore.session(authorizer) as session:
-        data2 = session.request("GET", "/api/v1/user/{}/trophies".format(user))
+        data2 = session.request("GET", f"/api/v1/user/{user}/trophies")
 
     for trophy in data1["data"]["trophies"]:
         description = trophy["data"]["description"]
         print(
             "Original:",
             trophy["data"]["name"]
-            + (" ({})".format(description) if description else ""),
+            + (f" ({description})" if description else ""),
         )
 
     for trophy in data2["data"]["trophies"]:
@@ -73,7 +73,7 @@ def main():
         print(
             "Cached:",
             trophy["data"]["name"]
-            + (" ({})".format(description) if description else ""),
+            + (f" ({description})" if description else ""),
         )
     print(
         "----\nCached == Original:",

--- a/examples/device_id_auth_trophies.py
+++ b/examples/device_id_auth_trophies.py
@@ -14,7 +14,7 @@ import sys
 def main():
     """Provide the program's entry point when directly executed."""
     if len(sys.argv) != 2:
-        print("Usage: {} USERNAME".format(sys.argv[0]))
+        print(f"Usage: {sys.argv[0]} USERNAME")
         return 1
 
     authenticator = prawcore.UntrustedAuthenticator(
@@ -26,13 +26,13 @@ def main():
 
     user = sys.argv[1]
     with prawcore.session(authorizer) as session:
-        data = session.request("GET", "/api/v1/user/{}/trophies".format(user))
+        data = session.request("GET", f"/api/v1/user/{user}/trophies")
 
     for trophy in data["data"]["trophies"]:
         description = trophy["data"]["description"]
         print(
             trophy["data"]["name"]
-            + (" ({})".format(description) if description else "")
+            + (f" ({description})" if description else "")
         )
 
     return 0

--- a/examples/device_id_auth_trophies.py
+++ b/examples/device_id_auth_trophies.py
@@ -7,8 +7,9 @@ This program demonstrates the use of ``prawcore.DeviceIDAuthorizer``.
 """
 
 import os
-import prawcore
 import sys
+
+import prawcore
 
 
 def main():

--- a/examples/obtain_refresh_token.py
+++ b/examples/obtain_refresh_token.py
@@ -34,14 +34,14 @@ def receive_connection():
 def send_message(client, message):
     """Send message to client and close the connection."""
     print(message)
-    client.send("HTTP/1.1 200 OK\r\n\r\n{}".format(message).encode("utf-8"))
+    client.send(f"HTTP/1.1 200 OK\r\n\r\n{message}".encode("utf-8"))
     client.close()
 
 
 def main():
     """Provide the program's entry point when directly executed."""
     if len(sys.argv) < 2:
-        print("Usage: {} SCOPE...".format(sys.argv[0]))
+        print(f"Usage: {sys.argv[0]} SCOPE...")
         return 1
 
     authenticator = prawcore.TrustedAuthenticator(
@@ -66,9 +66,7 @@ def main():
     if state != params["state"]:
         send_message(
             client,
-            "State mismatch. Expected: {} Received: {}".format(
-                state, params["state"]
-            ),
+            f"State mismatch. Expected: {state} Received: {params['state']}",
         )
         return 1
     elif "error" in params:
@@ -78,7 +76,7 @@ def main():
     authorizer = prawcore.Authorizer(authenticator)
     authorizer.authorize(params["code"])
 
-    send_message(client, "Refresh token: {}".format(authorizer.refresh_token))
+    send_message(client, f"Refresh token: {authorizer.refresh_token}")
     return 0
 
 

--- a/examples/obtain_refresh_token.py
+++ b/examples/obtain_refresh_token.py
@@ -10,10 +10,11 @@ your web application OAuth2 credentials.
 
 """
 import os
-import prawcore
 import random
 import socket
 import sys
+
+import prawcore
 
 
 def receive_connection():

--- a/examples/read_only_auth_trophies.py
+++ b/examples/read_only_auth_trophies.py
@@ -14,7 +14,7 @@ import sys
 def main():
     """Provide the program's entry point when directly executed."""
     if len(sys.argv) != 2:
-        print("Usage: {} USERNAME".format(sys.argv[0]))
+        print(f"Usage: {sys.argv[0]} USERNAME")
         return 1
 
     authenticator = prawcore.TrustedAuthenticator(
@@ -27,13 +27,13 @@ def main():
 
     user = sys.argv[1]
     with prawcore.session(authorizer) as session:
-        data = session.request("GET", "/api/v1/user/{}/trophies".format(user))
+        data = session.request("GET", f"/api/v1/user/{user}/trophies")
 
     for trophy in data["data"]["trophies"]:
         description = trophy["data"]["description"]
         print(
             trophy["data"]["name"]
-            + (" ({})".format(description) if description else "")
+            + (f" ({description})" if description else "")
         )
 
     return 0

--- a/examples/read_only_auth_trophies.py
+++ b/examples/read_only_auth_trophies.py
@@ -7,8 +7,9 @@ not require an access token to make authenticated requests to reddit.
 
 """
 import os
-import prawcore
 import sys
+
+import prawcore
 
 
 def main():

--- a/examples/script_auth_friend_list.py
+++ b/examples/script_auth_friend_list.py
@@ -8,8 +8,9 @@ their username and password.
 
 """
 import os
-import prawcore
 import sys
+
+import prawcore
 
 
 def main():

--- a/prawcore/__init__.py
+++ b/prawcore/__init__.py
@@ -1,11 +1,12 @@
 """prawcore: Low-level communication layer for PRAW 4+."""
 
 import logging
+
 from .auth import (  # noqa
     Authorizer,
     DeviceIDAuthorizer,
-    ReadOnlyAuthorizer,
     ImplicitAuthorizer,
+    ReadOnlyAuthorizer,
     ScriptAuthorizer,
     TrustedAuthenticator,
     UntrustedAuthenticator,
@@ -14,6 +15,5 @@ from .const import __version__  # noqa
 from .exceptions import *  # noqa
 from .requestor import Requestor  # noqa
 from .sessions import Session, session  # noqa
-
 
 logging.getLogger(__package__).addHandler(logging.NullHandler())

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -168,9 +168,7 @@ class BaseAuthorizer(object):
     def _validate_authenticator(self):
         if not isinstance(self._authenticator, self.AUTHENTICATOR_CLASS):
             raise InvalidInvocation(
-                "Must use a authenticator of type {}.".format(
-                    self.AUTHENTICATOR_CLASS.__name__
-                )
+                f"Must use a authenticator of type {self.AUTHENTICATOR_CLASS.__name__}."
             )
 
     def is_valid(self):

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -1,9 +1,11 @@
 """Provides Authentication and Authorization classes."""
 import time
-from . import const
-from .exceptions import InvalidInvocation, OAuthException, ResponseException
+
 from requests import Request
 from requests.status_codes import codes
+
+from . import const
+from .exceptions import InvalidInvocation, OAuthException, ResponseException
 
 
 class BaseAuthenticator(object):

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -57,7 +57,7 @@ class BaseAuthenticator(object):
             raise InvalidInvocation("redirect URI not provided")
         if implicit and not isinstance(self, UntrustedAuthenticator):
             raise InvalidInvocation(
-                "Only UntrustedAuthentictor instances can "
+                "Only UntrustedAuthenticator instances can "
                 "use the implicit grant flow."
             )
         if implicit and duration != "temporary":

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -16,10 +16,10 @@ class BaseAuthenticator(object):
 
         :param requestor: An instance of :class:`Requestor`.
         :param client_id: The OAuth2 client ID to use with the session.
-        :param redirect_uri: (optional) The redirect URI exactly as specified
-            in your OAuth application settings on Reddit. This parameter is
-            required if you want to use the ``authorize_url`` method, or the
-            ``authorize`` method of the ``Authorizer`` class.
+        :param redirect_uri: (optional) The redirect URI exactly as specified in your
+            OAuth application settings on Reddit. This parameter is required if you want
+            to use the ``authorize_url`` method, or the ``authorize`` method of the
+            ``Authorizer`` class.
 
         """
         self._requestor = requestor
@@ -42,17 +42,16 @@ class BaseAuthenticator(object):
         """Return the URL used out-of-band to grant access to your application.
 
         :param duration: Either ``permanent`` or ``temporary``. ``temporary``
-            authorizations generate access tokens that last only 1
-            hour. ``permanent`` authorizations additionally generate a refresh
-            token that can be indefinitely used to generate new hour-long
-            access tokens. Only ``temporary`` can be specified if ``implicit``
-            is set to ``True``.
+            authorizations generate access tokens that last only 1 hour. ``permanent``
+            authorizations additionally generate a refresh token that can be
+            indefinitely used to generate new hour-long access tokens. Only
+            ``temporary`` can be specified if ``implicit`` is set to ``True``.
         :param scopes: A list of OAuth scopes to request authorization for.
         :param state: A string that will be reflected in the callback to
-            ``redirect_uri``. This value should be temporarily unique to the
-            client for whom the URL was generated for.
-        :param implicit: (optional) Use the implicit grant flow (default:
-            False). This flow is only available for UntrustedAuthenticators.
+            ``redirect_uri``. This value should be temporarily unique to the client for
+            whom the URL was generated for.
+        :param implicit: (optional) Use the implicit grant flow (default: False). This
+            flow is only available for UntrustedAuthenticators.
 
         """
         if self.redirect_uri is None:
@@ -84,9 +83,9 @@ class BaseAuthenticator(object):
         """Ask Reddit to revoke the provided token.
 
         :param token: The access or refresh token to revoke.
-        :param token_type: (Optional) When provided, hint to Reddit what the
-            token type is for a possible efficiency gain. The value can be
-            either ``access_token`` or ``refresh_token``.
+        :param token_type: (Optional) When provided, hint to Reddit what the token type
+            is for a possible efficiency gain. The value can be either ``access_token``
+            or ``refresh_token``.
 
         """
         data = {"token": token}
@@ -107,10 +106,10 @@ class TrustedAuthenticator(BaseAuthenticator):
         :param requestor: An instance of :class:`Requestor`.
         :param client_id: The OAuth2 client ID to use with the session.
         :param client_secret: The OAuth2 client secret to use with the session.
-        :param redirect_uri: (optional) The redirect URI exactly as specified
-            in your OAuth application settings on Reddit. This parameter is
-            required if you want to use the ``authorize_url`` method, or the
-            ``authorize`` method of the ``Authorizer`` class.
+        :param redirect_uri: (optional) The redirect URI exactly as specified in your
+            OAuth application settings on Reddit. This parameter is required if you want
+            to use the ``authorize_url`` method, or the ``authorize`` method of the
+            ``Authorizer`` class.
 
         """
         super(TrustedAuthenticator, self).__init__(
@@ -119,14 +118,14 @@ class TrustedAuthenticator(BaseAuthenticator):
         self.client_secret = client_secret
 
     def _auth(self):
-        return (self.client_id, self.client_secret)
+        return self.client_id, self.client_secret
 
 
 class UntrustedAuthenticator(BaseAuthenticator):
     """Store OAuth2 authentication credentials for installed applications."""
 
     def _auth(self):
-        return (self.client_id, "")
+        return self.client_id, ""
 
 
 class BaseAuthorizer(object):
@@ -177,8 +176,8 @@ class BaseAuthorizer(object):
     def is_valid(self):
         """Return whether or not the Authorizer is ready to authorize requests.
 
-        A ``True`` return value does not guarantee that the access_token is
-        actually valid on the server side.
+        A ``True`` return value does not guarantee that the access_token is actually
+        valid on the server side.
 
         """
         return (
@@ -203,8 +202,7 @@ class Authorizer(BaseAuthorizer):
     def __init__(self, authenticator, refresh_token=None):
         """Represent a single authorization to Reddit's API.
 
-        :param authenticator: An instance of a subclass of
-            :class:`BaseAuthenticator`.
+        :param authenticator: An instance of a subclass of :class:`BaseAuthenticator`.
         :param refresh_token: (Optional) Enables the ability to refresh the
             authorization.
 
@@ -215,8 +213,8 @@ class Authorizer(BaseAuthorizer):
     def authorize(self, code):
         """Obtain and set authorization tokens based on ``code``.
 
-        :param code: The code obtained by an out-of-band authorization request
-            to Reddit.
+        :param code: The code obtained by an out-of-band authorization request to
+            Reddit.
 
         """
         if self._authenticator.redirect_uri is None:
@@ -238,11 +236,11 @@ class Authorizer(BaseAuthorizer):
     def revoke(self, only_access=False):
         """Revoke the current Authorization.
 
-        :param only_access: (Optional) When explicitly set to True, do not
-            evict the refresh token if one is set.
+        :param only_access: (Optional) When explicitly set to True, do not evict the
+            refresh token if one is set.
 
-        Revoking a refresh token will in-turn revoke all access tokens
-        associated with that authorization.
+        Revoking a refresh token will in-turn revoke all access tokens associated with
+        that authorization.
 
         """
         if only_access or self.refresh_token is None:
@@ -258,8 +256,8 @@ class Authorizer(BaseAuthorizer):
 class DeviceIDAuthorizer(BaseAuthorizer):
     """Manages app-only OAuth2 for 'installed' applications.
 
-    While the '*' scope will be available, some endpoints simply will not work
-    due to the lack of an associated Reddit account.
+    While the '*' scope will be available, some endpoints simply will not work due to
+    the lack of an associated Reddit account.
 
     """
 
@@ -269,10 +267,10 @@ class DeviceIDAuthorizer(BaseAuthorizer):
         """Represent an app-only OAuth2 authorization for 'installed' apps.
 
         :param authenticator: An instance of :class:`UntrustedAuthenticator`.
-        :param device_id: (optional) A unique ID (20-30 character ASCII string)
-            (default DO_NOT_TRACK_THIS_DEVICE). For more information about this
-            parameter, see:
+        :param device_id: (optional) A unique ID (20-30 character ASCII string) (default
+            DO_NOT_TRACK_THIS_DEVICE). For more information about this parameter, see:
             https://github.com/reddit/reddit/wiki/OAuth2#application-only-oauth
+
         """
         super(DeviceIDAuthorizer, self).__init__(authenticator)
         self._device_id = device_id
@@ -292,17 +290,15 @@ class ImplicitAuthorizer(BaseAuthorizer):
         """Represent a single implicit authorization to Reddit's API.
 
         :param authenticator: An instance of :class:`UntrustedAuthenticator`.
-        :param access_token: The access_token obtained from Reddit via callback
-            to the authenticator's redirect_uri.
-        :param expires_in: The number of seconds the ``access_token`` is valid
-            for. The origin of this value was returned from Reddit via callback
-            to the authenticator's redirect uri. Note, you may need to subtract
-            an offset before passing in this number to account for a delay
-            between when Reddit prepared the response, and when you make this
-            function call.
-        :param scope: A space-delimited string of Reddit OAuth2 scope names as
-            returned from Reddit in the callback to the authenticator's
-            redirect uri.
+        :param access_token: The access_token obtained from Reddit via callback to the
+            authenticator's redirect_uri.
+        :param expires_in: The number of seconds the ``access_token`` is valid for. The
+            origin of this value was returned from Reddit via callback to the
+            authenticator's redirect uri. Note, you may need to subtract an offset
+            before passing in this number to account for a delay between when Reddit
+            prepared the response, and when you make this function call.
+        :param scope: A space-delimited string of Reddit OAuth2 scope names as returned
+            from Reddit in the callback to the authenticator's redirect uri.
 
         """
         super(ImplicitAuthorizer, self).__init__(authenticator)
@@ -314,8 +310,8 @@ class ImplicitAuthorizer(BaseAuthorizer):
 class ReadOnlyAuthorizer(Authorizer):
     """Manages authorizations that are not associated with a Reddit account.
 
-    While the '*' scope will be available, some endpoints simply will not work
-    due to the lack of an associated Reddit account.
+    While the '*' scope will be available, some endpoints simply will not work due to
+    the lack of an associated Reddit account.
 
     """
 
@@ -329,8 +325,8 @@ class ReadOnlyAuthorizer(Authorizer):
 class ScriptAuthorizer(Authorizer):
     """Manages personal-use script type authorizations.
 
-    Only users who are listed as developers for the application will be
-    granted access tokens.
+    Only users who are listed as developers for the application will be granted access
+    tokens.
 
     """
 
@@ -340,8 +336,7 @@ class ScriptAuthorizer(Authorizer):
         """Represent a single personal-use authorization to Reddit's API.
 
         :param authenticator: An instance of :class:`TrustedAuthenticator`.
-        :param username: The Reddit username of one of the application's
-            developers.
+        :param username: The Reddit username of one of the application's developers.
         :param password: The password associated with ``username``.
 
         """

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -170,7 +170,8 @@ class BaseAuthorizer(object):
     def _validate_authenticator(self):
         if not isinstance(self._authenticator, self.AUTHENTICATOR_CLASS):
             raise InvalidInvocation(
-                f"Must use a authenticator of type {self.AUTHENTICATOR_CLASS.__name__}."
+                "Must use a authenticator of type"
+                f" {self.AUTHENTICATOR_CLASS.__name__}."
             )
 
     def is_valid(self):

--- a/prawcore/exceptions.py
+++ b/prawcore/exceptions.py
@@ -140,9 +140,7 @@ class SpecialError(ResponseException):
         self.message = resp_dict.get("message", "")
         self.reason = resp_dict.get("reason", "")
         self.special_errors = resp_dict.get("special_errors", [])
-        PrawcoreException.__init__(
-            self, f"Special error {self.message!r}"
-        )
+        PrawcoreException.__init__(self, f"Special error {self.message!r}")
 
 
 class TooLarge(ResponseException):

--- a/prawcore/exceptions.py
+++ b/prawcore/exceptions.py
@@ -25,7 +25,7 @@ class RequestException(PrawcoreException):
         self.request_args = request_args
         self.request_kwargs = request_kwargs
         super(RequestException, self).__init__(
-            "error with request {}".format(original_exception)
+            f"error with request {original_exception}"
         )
 
 
@@ -40,7 +40,7 @@ class ResponseException(PrawcoreException):
         """
         self.response = response
         super(ResponseException, self).__init__(
-            "received {} HTTP response".format(response.status_code)
+            f"received {response.status_code} HTTP response"
         )
 
 
@@ -58,9 +58,9 @@ class OAuthException(PrawcoreException):
         self.error = error
         self.description = description
         self.response = response
-        message = "{} error processing request".format(error)
+        message = f"{error} error processing request"
         if description:
-            message += " ({})".format(description)
+            message += f" ({description})"
         PrawcoreException.__init__(self, message)
 
 
@@ -110,7 +110,7 @@ class Redirect(ResponseException):
         path = urlparse(response.headers["location"]).path
         self.path = path[:-5] if path.endswith(".json") else path
         self.response = response
-        msg = "Redirect to {}".format(self.path)
+        msg = f"Redirect to {self.path}"
         msg += (
             " (You may be trying to perform a non-read-only action via a "
             "read-only instance.)"
@@ -141,7 +141,7 @@ class SpecialError(ResponseException):
         self.reason = resp_dict.get("reason", "")
         self.special_errors = resp_dict.get("special_errors", [])
         PrawcoreException.__init__(
-            self, "Special error {!r}".format(self.message)
+            self, f"Special error {self.message!r}"
         )
 
 

--- a/prawcore/exceptions.py
+++ b/prawcore/exceptions.py
@@ -48,7 +48,7 @@ class OAuthException(PrawcoreException):
     """Indicate that there was an OAuth2 related error with the request."""
 
     def __init__(self, response, error, description):
-        """Intialize a OAuthException instance.
+        """Initialize a OAuthException instance.
 
         :param response: A requests.response instance.
         :param error: The error type returned by reddit.
@@ -150,4 +150,4 @@ class TooLarge(ResponseException):
 
 
 class UnavailableForLegalReasons(ResponseException):
-    """Indicate that the requested URL is unavilable due to legal reasons."""
+    """Indicate that the requested URL is unavailable due to legal reasons."""

--- a/prawcore/exceptions.py
+++ b/prawcore/exceptions.py
@@ -95,16 +95,15 @@ class NotFound(ResponseException):
 class Redirect(ResponseException):
     """Indicate the request resulted in a redirect.
 
-    This class adds the attribute ``path``, which is the path to which the
-    response redirects.
+    This class adds the attribute ``path``, which is the path to which the response
+    redirects.
 
     """
 
     def __init__(self, response):
         """Initialize a Redirect exception instance.
 
-        :param response: A requests.response instance containing a location
-        header.
+        :param response: A requests.response instance containing a location header.
 
         """
         path = urlparse(response.headers["location"]).path
@@ -130,8 +129,8 @@ class SpecialError(ResponseException):
     def __init__(self, response):
         """Initialize a SpecialError exception instance.
 
-        :param response: A requests.response instance containing a message
-        and a list of special errors.
+        :param response: A requests.response instance containing a message and a list of
+            special errors.
 
         """
         self.response = response

--- a/prawcore/rate_limit.py
+++ b/prawcore/rate_limit.py
@@ -44,9 +44,7 @@ class RateLimiter(object):
         sleep_seconds = self.next_request_timestamp - time.time()
         if sleep_seconds <= 0:
             return
-        message = "Sleeping: {:0.2f} seconds prior to" " call".format(
-            sleep_seconds
-        )
+        message = f"Sleeping: {sleep_seconds:0.2f} seconds prior to call"
         log.debug(message)
         time.sleep(sleep_seconds)
 

--- a/prawcore/rate_limit.py
+++ b/prawcore/rate_limit.py
@@ -22,13 +22,11 @@ class RateLimiter(object):
     def call(self, request_function, set_header_callback, *args, **kwargs):
         """Rate limit the call to request_function.
 
-        :param request_function: A function call that returns an HTTP response
-            object.
-        :param set_header_callback: A callback function used to set the request
-            headers. This callback is called after any necessary sleep time
-            occurs.
-        :param *args: The positional arguments to ``request_function``.
-        :param **kwargs: The keyword arguments to ``request_function``.
+        :param request_function: A function call that returns an HTTP response object.
+        :param set_header_callback: A callback function used to set the request headers.
+            This callback is called after any necessary sleep time occurs.
+        :param args: The positional arguments to ``request_function``.
+        :param kwargs: The keyword arguments to ``request_function``.
 
         """
         self.delay()
@@ -53,9 +51,9 @@ class RateLimiter(object):
 
         This method should only be called following a HTTP request to reddit.
 
-        Response headers that do not contain x-ratelimit fields will be treated
-        as a single request. This behavior is to error on the safe-side as such
-        responses should trigger exceptions that indicate invalid behavior.
+        Response headers that do not contain x-ratelimit fields will be treated as a
+        single request. This behavior is to error on the safe-side as such responses
+        should trigger exceptions that indicate invalid behavior.
 
         """
         if "x-ratelimit-remaining" not in response_headers:

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -36,9 +36,7 @@ class Requestor(object):
             raise InvalidInvocation("user_agent is not descriptive")
 
         self._http = session or requests.Session()
-        self._http.headers["User-Agent"] = "{} prawcore/{}".format(
-            user_agent, __version__
-        )
+        self._http.headers["User-Agent"] = f"{user_agent} prawcore/{__version__}"
 
         self.oauth_url = oauth_url
         self.reddit_url = reddit_url

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -37,7 +37,9 @@ class Requestor(object):
             raise InvalidInvocation("user_agent is not descriptive")
 
         self._http = session or requests.Session()
-        self._http.headers["User-Agent"] = f"{user_agent} prawcore/{__version__}"
+        self._http.headers[
+            "User-Agent"
+        ] = f"{user_agent} prawcore/{__version__}"
 
         self.oauth_url = oauth_url
         self.reddit_url = reddit_url

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -23,15 +23,15 @@ class Requestor(object):
     ):
         """Create an instance of the Requestor class.
 
-        :param user_agent: The user-agent for your application. Please follow
-            reddit's user-agent guidelines:
-            https://github.com/reddit/reddit/wiki/API#rules
-        :param oauth_url: (Optional) The URL used to make OAuth requests to the
-            reddit site. (Default: https://oauth.reddit.com)
-        :param reddit_url: (Optional) The URL used when obtaining access
-            tokens. (Default: https://www.reddit.com)
-        :param session: (Optional) A session to handle requests, compatible
-            with requests.Session(). (Default: None)
+        :param user_agent: The user-agent for your application. Please follow reddit's
+            user-agent guidelines: https://github.com/reddit/reddit/wiki/API#rules
+        :param oauth_url: (Optional) The URL used to make OAuth requests to the reddit
+            site. (Default: https://oauth.reddit.com)
+        :param reddit_url: (Optional) The URL used when obtaining access tokens.
+            (Default: https://www.reddit.com)
+        :param session: (Optional) A session to handle requests, compatible with
+            requests.Session(). (Default: None)
+
         """
         if user_agent is None or len(user_agent) < 7:
             raise InvalidInvocation("user_agent is not descriptive")

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -23,7 +23,7 @@ class Requestor(object):
         """Create an instance of the Requestor class.
 
         :param user_agent: The user-agent for your application. Please follow
-            reddit's user-agent guidlines:
+            reddit's user-agent guidelines:
             https://github.com/reddit/reddit/wiki/API#rules
         :param oauth_url: (Optional) The URL used to make OAuth requests to the
             reddit site. (Default: https://oauth.reddit.com)

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -1,6 +1,7 @@
 """Provides the HTTP request handling interface."""
 import requests
-from .const import __version__, TIMEOUT
+
+from .const import TIMEOUT, __version__
 from .exceptions import InvalidInvocation, RequestException
 
 

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -118,7 +118,7 @@ class Session(object):
         log.debug("Params: {}".format(params))
 
     def __init__(self, authorizer):
-        """Preprare the connection to reddit's API.
+        """Prepare the connection to reddit's API.
 
         :param authorizer: An instance of :class:`Authorizer`.
 

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -46,9 +46,7 @@ class RetryStrategy(object):
         """Sleep until we are ready to attempt the request."""
         sleep_seconds = self._sleep_seconds()
         if sleep_seconds is not None:
-            message = "Sleeping: {:0.2f} seconds prior to retry".format(
-                sleep_seconds
-            )
+            message = f"Sleeping: {sleep_seconds:0.2f} seconds prior to retry"
             log.debug(message)
             time.sleep(sleep_seconds)
 
@@ -113,9 +111,9 @@ class Session(object):
 
     @staticmethod
     def _log_request(data, method, params, url):
-        log.debug("Fetching: {} {}".format(method, url))
-        log.debug("Data: {}".format(data))
-        log.debug("Params: {}".format(params))
+        log.debug(f"Fetching: {method} {url}")
+        log.debug(f"Data: {data}")
+        log.debug(f"Params: {params}")
 
     def __init__(self, authorizer):
         """Prepare the connection to reddit's API.
@@ -125,7 +123,7 @@ class Session(object):
         """
         if not isinstance(authorizer, BaseAuthorizer):
             raise InvalidInvocation(
-                "invalid Authorizer: {}".format(authorizer)
+                f"invalid Authorizer: {authorizer}"
             )
         self._authorizer = authorizer
         self._rate_limiter = RateLimiter()
@@ -157,7 +155,7 @@ class Session(object):
         else:
             status = response.status_code
         log.warning(
-            "Retrying due to {} status: {} {}".format(status, method, url)
+            f"Retrying due to {status} status: {method} {url}"
         )
         return self._request_with_retries(
             data=data,
@@ -195,10 +193,7 @@ class Session(object):
                 timeout=timeout,
             )
             log.debug(
-                "Response: {} ({} bytes)".format(
-                    response.status_code,
-                    response.headers.get("content-length"),
-                )
+                f"Response: {response.status_code} ({response.headers.get('content-length')} bytes)"
             )
             return response, None
         except RequestException as exception:
@@ -267,7 +262,7 @@ class Session(object):
             return
         assert (
             response.status_code in self.SUCCESS_STATUSES
-        ), "Unexpected status code: {}".format(response.status_code)
+        ), f"Unexpected status code: {response.status_code}"
         if response.headers.get("content-length") == "0":
             return ""
         try:
@@ -281,7 +276,7 @@ class Session(object):
         ):
             self._authorizer.refresh()
         return {
-            "Authorization": "bearer {}".format(self._authorizer.access_token)
+            "Authorization": f"bearer {self._authorizer.access_token}"
         }
 
     @property

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -298,18 +298,17 @@ class Session(object):
         """Return the json content from the resource at ``path``.
 
         :param method: The request verb. E.g., get, post, put.
-        :param path: The path of the request. This path will be combined with
-            the ``oauth_url`` of the Requestor.
-        :param data: Dictionary, bytes, or file-like object to send in the body
-            of the request.
-        :param files: Dictionary, mapping ``filename`` to file-like object.
-        :param json: Object to be serialized to JSON in the body of the
+        :param path: The path of the request. This path will be combined with the
+            ``oauth_url`` of the Requestor.
+        :param data: Dictionary, bytes, or file-like object to send in the body of the
             request.
+        :param files: Dictionary, mapping ``filename`` to file-like object.
+        :param json: Object to be serialized to JSON in the body of the request.
         :param params: The query parameters to send with the request.
 
-        Automatically refreshes the access token if it becomes invalid and a
-        refresh token is available. Raises InvalidInvocation in such a case if
-        a refresh token is not available.
+        Automatically refreshes the access token if it becomes invalid and a refresh
+        token is available. Raises InvalidInvocation in such a case if a refresh token
+        is not available.
 
         """
         params = deepcopy(params) or {}

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -1,9 +1,9 @@
 """prawcore.sessions: Provides prawcore.Session and prawcore.session."""
-from copy import deepcopy
-from urllib.parse import urljoin
 import logging
 import random
 import time
+from copy import deepcopy
+from urllib.parse import urljoin
 
 from requests.exceptions import (
     ChunkedEncodingError,
@@ -14,7 +14,6 @@ from requests.status_codes import codes
 
 from .auth import BaseAuthorizer
 from .const import TIMEOUT
-from .rate_limit import RateLimiter
 from .exceptions import (
     BadJSON,
     BadRequest,
@@ -28,6 +27,7 @@ from .exceptions import (
     TooLarge,
     UnavailableForLegalReasons,
 )
+from .rate_limit import RateLimiter
 from .util import authorization_error_class
 
 log = logging.getLogger(__package__)

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -122,9 +122,7 @@ class Session(object):
 
         """
         if not isinstance(authorizer, BaseAuthorizer):
-            raise InvalidInvocation(
-                f"invalid Authorizer: {authorizer}"
-            )
+            raise InvalidInvocation(f"invalid Authorizer: {authorizer}")
         self._authorizer = authorizer
         self._rate_limiter = RateLimiter()
         self._retry_strategy_class = FiniteRetryStrategy
@@ -154,9 +152,7 @@ class Session(object):
             status = repr(saved_exception)
         else:
             status = response.status_code
-        log.warning(
-            f"Retrying due to {status} status: {method} {url}"
-        )
+        log.warning(f"Retrying due to {status} status: {method} {url}")
         return self._request_with_retries(
             data=data,
             files=files,
@@ -193,12 +189,16 @@ class Session(object):
                 timeout=timeout,
             )
             log.debug(
-                f"Response: {response.status_code} ({response.headers.get('content-length')} bytes)"
+                f"Response: {response.status_code}"
+                f" ({response.headers.get('content-length')} bytes)"
             )
             return response, None
         except RequestException as exception:
-            if not retry_strategy_state.should_retry_on_failure() or not isinstance(  # noqa: E501
-                exception.original_exception, self.RETRY_EXCEPTIONS
+            if (
+                not retry_strategy_state.should_retry_on_failure()
+                or not isinstance(  # noqa: E501
+                    exception.original_exception, self.RETRY_EXCEPTIONS
+                )
             ):
                 raise
             return None, exception.original_exception
@@ -275,9 +275,7 @@ class Session(object):
             self._authorizer, "refresh"
         ):
             self._authorizer.refresh()
-        return {
-            "Authorization": f"bearer {self._authorizer.access_token}"
-        }
+        return {"Authorization": f"bearer {self._authorizer.access_token}"}
 
     @property
     def _requestor(self):

--- a/prawcore/util.py
+++ b/prawcore/util.py
@@ -1,7 +1,6 @@
 """Provide utility for the prawcore package."""
 from .exceptions import Forbidden, InsufficientScope, InvalidToken
 
-
 _auth_error_mapping = {
     403: Forbidden,
     "insufficient_scope": InsufficientScope,

--- a/pre_push.sh
+++ b/pre_push.sh
@@ -5,6 +5,7 @@ function exit_error() {
     exit 1
 }
 
+flynt -q -tc -ll  1000 . || exit_error "Please install flynt: pip install flynt"
 black *.py examples prawcore tests || exit_error "Please install black: pip install black"
 
 python setup.py test || exit_error "Please fix test issues."

--- a/pre_push.sh
+++ b/pre_push.sh
@@ -14,7 +14,7 @@ flake8 --version > /dev/null 2>&1
 if [ $? -ne 0 ]; then
     exit_error "Please install flake8: pip install flake8"
 fi
-flake8 || exit_error "Please correct flake8 issues."
+flake8 --exclude=.eggs,.venv || exit_error "Please correct flake8 issues."
 echo "style pass!"
 
 pydocstyle --version > /dev/null 2>&1

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 import re
 from codecs import open
 from os import path
-from setuptools import setup
 
+from setuptools import setup
 
 PACKAGE_NAME = "prawcore"
 HERE = path.abspath(path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(HERE, PACKAGE_NAME, "const.py"), encoding="utf-8") as fp:
 
 extras = {
     "ci": ["coveralls"],
-    "lint": ["black", "flake8", "pre-commit", "pydocstyle"],
+    "lint": ["black", "flake8", "pre-commit", "pydocstyle", "flynt"],
     "test": [
         "betamax >=0.8, <0.9",
         "betamax_matchers >=0.4.0, <0.5",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
 """Test prawcore."""
 import time
 
-
 time.sleep = lambda x: None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ with Betamax.configure() as config:
     config.default_cassette_options["serialize_with"] = "prettyjson"
     config.default_cassette_options["match_requests_on"].append("body")
     config.define_cassette_placeholder(
-        "<BASIC_AUTH>", b64_string("{}:{}".format(CLIENT_ID, CLIENT_SECRET))
+        "<BASIC_AUTH>", b64_string(f"{CLIENT_ID}:{CLIENT_SECRET}")
     )
     config.define_cassette_placeholder("<CLIENT_ID>", CLIENT_ID)
     config.define_cassette_placeholder("<CLIENT_SECRET>", CLIENT_SECRET)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,11 @@
 
 import os
 from base64 import b64encode
+
 from betamax import Betamax
 from betamax_matchers.json_body import JSONBodyMatcher
 from betamax_serializers import pretty_json
+
 from prawcore import Requestor
 
 CLIENT_ID = os.environ.get("PRAWCORE_CLIENT_ID", "fake_client_id")

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -13,7 +13,7 @@ class TrustedAuthenticatorTest(unittest.TestCase):
         url = authenticator.authorize_url(
             "permanent", ["identity", "read"], "a_state"
         )
-        self.assertIn("client_id={}".format(CLIENT_ID), url)
+        self.assertIn(f"client_id={CLIENT_ID}", url)
         self.assertIn("duration=permanent", url)
         self.assertIn("response_type=code", url)
         self.assertIn("scope=identity+read", url)
@@ -80,7 +80,7 @@ class UntrustedAuthenticatorTest(unittest.TestCase):
         url = authenticator.authorize_url(
             "permanent", ["identity", "read"], "a_state"
         )
-        self.assertIn("client_id={}".format(CLIENT_ID), url)
+        self.assertIn(f"client_id={CLIENT_ID}", url)
         self.assertIn("duration=permanent", url)
         self.assertIn("response_type=code", url)
         self.assertIn("scope=identity+read", url)
@@ -93,7 +93,7 @@ class UntrustedAuthenticatorTest(unittest.TestCase):
         url = authenticator.authorize_url(
             "temporary", ["identity", "read"], "a_state", implicit=True
         )
-        self.assertIn("client_id={}".format(CLIENT_ID), url)
+        self.assertIn(f"client_id={CLIENT_ID}", url)
         self.assertIn("duration=temporary", url)
         self.assertIn("response_type=token", url)
         self.assertIn("scope=identity+read", url)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1,8 +1,11 @@
 """Test for subclasses of prawcore.auth.BaseAuthenticator class."""
-import prawcore
 import unittest
-from .conftest import CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, REQUESTOR
+
 from betamax import Betamax
+
+import prawcore
+
+from .conftest import CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, REQUESTOR
 
 
 class TrustedAuthenticatorTest(unittest.TestCase):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1,4 +1,4 @@
-"""Test for sublcasses of prawcore.auth.BaseAuthenticator class."""
+"""Test for subclasses of prawcore.auth.BaseAuthenticator class."""
 import prawcore
 import unittest
 from .conftest import CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, REQUESTOR

--- a/tests/test_authorizer.py
+++ b/tests/test_authorizer.py
@@ -1,6 +1,10 @@
 """Test for prawcore.auth.Authorizer classes."""
-import prawcore
 import unittest
+
+from betamax import Betamax
+
+import prawcore
+
 from .conftest import (
     CLIENT_ID,
     CLIENT_SECRET,
@@ -12,7 +16,6 @@ from .conftest import (
     TEMPORARY_GRANT_CODE,
     USERNAME,
 )
-from betamax import Betamax
 
 
 class AuthorizerTestBase(unittest.TestCase):

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,8 +1,10 @@
 """Test for prawcore.Sessions module."""
-from copy import copy
-from mock import patch
-from prawcore.rate_limit import RateLimiter
 import unittest
+from copy import copy
+
+from mock import patch
+
+from prawcore.rate_limit import RateLimiter
 
 
 class RateLimiterTest(unittest.TestCase):

--- a/tests/test_requestor.py
+++ b/tests/test_requestor.py
@@ -1,9 +1,10 @@
 """Test for prawcore.requestor.Requestor class."""
 import pickle
+import unittest
+
+from mock import Mock, patch
 
 import prawcore
-import unittest
-from mock import patch, Mock
 from prawcore import RequestException
 
 

--- a/tests/test_requestor.py
+++ b/tests/test_requestor.py
@@ -11,9 +11,7 @@ class RequestorTest(unittest.TestCase):
     def test_initialize(self):
         requestor = prawcore.Requestor("prawcore:test (by /u/bboe)")
         self.assertEqual(
-            "prawcore:test (by /u/bboe) prawcore/{}".format(
-                prawcore.__version__
-            ),
+            f"prawcore:test (by /u/bboe) prawcore/{prawcore.__version__}",
             requestor._http.headers["User-Agent"],
         )
 
@@ -52,9 +50,7 @@ class RequestorTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            "prawcore:test (by /u/bboe) prawcore/{}".format(
-                prawcore.__version__
-            ),
+            f"prawcore:test (by /u/bboe) prawcore/{prawcore.__version__}",
             requestor._http.headers["User-Agent"],
         )
         self.assertEqual(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -452,7 +452,7 @@ class SessionTest(unittest.TestCase):
                 415, context_manager.exception.response.status_code
             )
 
-    def test_request__with_insufficent_scope(self):
+    def test_request__with_insufficient_scope(self):
         with Betamax(REQUESTOR).use_cassette(
             "Session_request__with_insufficient_scope"
         ):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -347,9 +347,7 @@ class SessionTest(unittest.TestCase):
         ):
             session = prawcore.Session(script_authorizer())
             data = {"model": dumps({"name": "redditdev"})}
-            path = "/api/multi/user/{}/m/praw_x5g968f66a/r/redditdev".format(
-                USERNAME
-            )
+            path = f"/api/multi/user/{USERNAME}/m/praw_x5g968f66a/r/redditdev"
             response = session.request("DELETE", path, data=data)
             self.assertEqual("", response)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,12 +1,10 @@
 """Test for prawcore.Sessions module."""
 import logging
+import unittest
 from json import dumps
 
-import prawcore
-import unittest
 from betamax import Betamax
 from mock import Mock, patch
-from prawcore.exceptions import RequestException
 from requests.exceptions import (
     ChunkedEncodingError,
     ConnectionError,
@@ -14,13 +12,16 @@ from requests.exceptions import (
 )
 from testfixtures import LogCapture
 
+import prawcore
+from prawcore.exceptions import RequestException
+
 from .conftest import (
     CLIENT_ID,
     CLIENT_SECRET,
+    PASSWORD,
     REFRESH_TOKEN,
     REQUESTOR,
-    PASSWORD,
-    USERNAME,
+    USERNAME
 )
 
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -21,7 +21,7 @@ from .conftest import (
     PASSWORD,
     REFRESH_TOKEN,
     REQUESTOR,
-    USERNAME
+    USERNAME,
 )
 
 
@@ -206,7 +206,7 @@ class SessionTest(unittest.TestCase):
             session = prawcore.Session(readonly_authorizer())
             response = session.request(
                 "GET",
-                ("/r/reddit_api_test/comments/" "45xjdr/want_raw_json_test/"),
+                "/r/reddit_api_test/comments/45xjdr/want_raw_json_test/",
             )
         self.assertEqual(
             "WANT_RAW_JSON test: < > &",


### PR DESCRIPTION
This PR does the following:

- Makes flake8 ignore `.eggs` and `.venv` directories
- Fixes spelling mistakes
- Converts `.format()` to f-string literal and adds `flynt` for enforcement
- Sorts imports with `isort`
- Formats code to 88 characters with black (one pass with --experimental-string-processing to normalize strings and a second pass without it)
- Cleans up docs:
  - Format docs to 88 characters where possible
  - Format all code snippets with black
  - Indent all blocks to 4 spaces
  - Change `*` bullets to `-`