### PR TITLE
Use sh syntax for pre_push.sh function

### DIFF
--- a/pre_push.sh
+++ b/pre_push.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function exit_error() {
+exit_error () {
     echo $1
     exit 1
 }


### PR DESCRIPTION
I guess `function foo ()` is bash syntax, so if you do `./pre_push.sh` then the `#!/bin/sh` shebang means that the script doesn't actually work.