### PR TITLE
Add note about valid authorize_url.state param

### DIFF
--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -48,8 +48,9 @@ class BaseAuthenticator(object):
             ``temporary`` can be specified if ``implicit`` is set to ``True``.
         :param scopes: A list of OAuth scopes to request authorization for.
         :param state: A string that will be reflected in the callback to
-            ``redirect_uri``. This value should be temporarily unique to the client for
-            whom the URL was generated for.
+            ``redirect_uri``. Elements must be printable ASCII characters in the range
+            0x20 through 0x7E inclusive. This value should be temporarily unique to the
+            client for whom the URL was generated for.
         :param implicit: (optional) Use the implicit grant flow (default: False). This
             flow is only available for UntrustedAuthenticators.
 

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -50,7 +50,7 @@ class BaseAuthenticator(object):
         :param state: A string that will be reflected in the callback to
             ``redirect_uri``. Elements must be printable ASCII characters in the range
             0x20 through 0x7E inclusive. This value should be temporarily unique to the
-            client for whom the URL was generated for.
+            client for whom the URL was generated.
         :param implicit: (optional) Use the implicit grant flow (default: False). This
             flow is only available for UntrustedAuthenticators.
 


### PR DESCRIPTION
Per RFC6749, this parameter must be in the ASCII range 0x20-0x7E.[^1]

Empirically, Reddit's response will not be usable if this rule is not
followed.

[1]: https://tools.ietf.org/html/rfc6749#appendix-A.5