### PR TITLE
Add two factor callback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 **Added**
 
 - Add a ``URITooLarge`` exception.
+- :class:`.ScriptAuthorizer` has a new parameter ``two_factor_callback `` that supplies
+  OTPs (One-Time Passcodes) when :meth:`.ScriptAuthorizer.refresh` is called.
 
 2.0.0 (2021-02-23)
 ------------------

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -356,17 +356,23 @@ class ScriptAuthorizer(Authorizer):
 
     AUTHENTICATOR_CLASS = TrustedAuthenticator
 
-    def __init__(self, authenticator, username, password):
+    def __init__(
+        self, authenticator, username, password, two_factor_callback=None
+    ):
         """Represent a single personal-use authorization to Reddit's API.
 
         :param authenticator: An instance of :class:`TrustedAuthenticator`.
         :param username: The Reddit username of one of the application's developers.
         :param password: The password associated with ``username``.
+        :param two_factor_callback: A function that returns OTPs (One-Time
+            Passcodes), also known as 2FA auth codes. If this function is
+            provided, prawcore will call it when authenticating.
 
         """
         super(ScriptAuthorizer, self).__init__(authenticator)
         self._username = username
         self._password = password
+        self._two_factor_callback = two_factor_callback
 
     def refresh(self):
         """Obtain a new personal-use script type access token."""
@@ -374,4 +380,5 @@ class ScriptAuthorizer(Authorizer):
             grant_type="password",
             username=self._username,
             password=self._password,
+            otp=self._two_factor_callback and self._two_factor_callback(),
         )

--- a/tests/cassettes/ScriptAuthorizer_refresh_with__invalid_otp.json
+++ b/tests/cassettes/ScriptAuthorizer_refresh_with__invalid_otp.json
@@ -1,0 +1,103 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-05-21T00:48:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&otp=fake&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "152"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=7C1qdPEdiInzFy9WaL; loid=bSusfEGk5JXrZYhhyW"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"error\": \"invalid_grant\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "26"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 21 May 2021 00:48:33 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297"
+          ],
+          "x-ratelimit-reset": [
+            "87"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/cassettes/ScriptAuthorizer_refresh_with__valid_otp.json
+++ b/tests/cassettes/ScriptAuthorizer_refresh_with__valid_otp.json
@@ -1,0 +1,103 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-05-21T00:43:11",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&otp=000000&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "152"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=W5X0f17fr5uGzS0Jxd; loid=yU0JIU6fMP2ZtL3FsU"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"00000000-000000000000000000000000000000\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "117"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 21 May 2021 00:43:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "406"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,11 @@ def b64_string(input_string):
     return b64encode(input_string.encode("utf-8")).decode("utf-8")
 
 
+def two_factor_callback():
+    """Return an OTP code."""
+    return None
+
+
 Betamax.register_request_matcher(JSONBodyMatcher)
 Betamax.register_serializer(pretty_json.PrettyJSONSerializer)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -22,6 +22,7 @@ from .conftest import (
     REFRESH_TOKEN,
     REQUESTOR,
     USERNAME,
+    two_factor_callback,
 )
 
 
@@ -60,7 +61,9 @@ def script_authorizer():
     authenticator = prawcore.TrustedAuthenticator(
         REQUESTOR, CLIENT_ID, CLIENT_SECRET
     )
-    authorizer = prawcore.ScriptAuthorizer(authenticator, USERNAME, PASSWORD)
+    authorizer = prawcore.ScriptAuthorizer(
+        authenticator, USERNAME, PASSWORD, two_factor_callback
+    )
     authorizer.refresh()
     return authorizer
 


### PR DESCRIPTION
This feature allows script authorizations to supply an optional 'otp' parameter when authenticating. This is accomplished by adding a callback named `two_factor_callback` to the method `ScriptAuthorizer.refresh.` See [97](https://github.com/praw-dev/prawcore/pull/97) and praw's [1496](https://github.com/praw-dev/praw/issues/1496) for previous discussions of this. 

---

I have added some support for running other tests with 2fa enabled. There is now a `test_two_factor_callback` function in conftest, which is used in script auth tests to generate an OTP. By default, it returns None, which allows all tests to pass. This PR also adds two tests that show what successful and unsuccessful authorization attempts look like. I have included a third test in test_authorizer, `test_refresh_with__2fa`, that is commented out and does not have a corresponding cassette. If you change `test_two_factor_callback` to something that will generate your real otp code, you can use this test to produce the same output as `test_refresh_with__valid_otp`. You don't need to install a separate library to run the test if you have already have a 2fa authenticator device, program, or app. Just change the definition of test_two_factor_callback from `return None` to `return input("OTP: ")`, run the test with pytest -s, and enter the code when prompted.

There are some issues with running tests with 2fa enabled. The uri for the initial authorization in all previous tests run with a password flow looks like

    "grant_type=password&password=<PASSWORD>&username=<USERNAME>"

but if you use 2fa, this changes to

    "grant_type=password&otp=123456&password=<PASSWORD>&username=<USERNAME>"`

This means that all tests which match uris will fail if you change the test_two_factor_callback to anything other than something that returns None. This could be dealt with by adding before_record and before_playback callbacks to the Betamax config, but I don't think it is worth doing that right now. Also, the rate limit for the password flow doesn't really allow you to record multiple tests at once. If you try, you will get the same `{'error': 'invalid_grant'}` message if you're still in timeout that you get when you supply the wrong credentials. The other flows aren't affected.

Other notes: if you don't have 2fa on your account, you can authorize with the otp parameter present as long as it is set to the empty string. If you make it anything other than the empty string, you'll get an invalid grant.