### PR TITLE
api/v1/revoke_token HTTP status code change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Unreleased
 
 - Support 202 "Accepted" HTTP responses.
 
+**Fixed**
+
+- The expected HTTP response status code for a request made with the proper credentials
+  to api/v1/revoke_token has been changed from 204 to 200.
+
 2.1.0 (2021-06-07)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Change Log
 
 prawcore follows `semantic versioning <http://semver.org/>`_.
 
+Unreleased
+----------
+
+**Added**
+
+- Support 202 "Accepted" HTTP responses.
+
 2.1.0 (2021-06-07)
 ------------------
 

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -93,7 +93,7 @@ class BaseAuthenticator(object):
         if token_type is not None:
             data["token_type_hint"] = token_type
         url = self._requestor.reddit_url + const.REVOKE_TOKEN_PATH
-        self._post(url, success_status=codes["no_content"], **data)
+        self._post(url, **data)
 
 
 class TrustedAuthenticator(BaseAuthenticator):

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -111,7 +111,7 @@ class Session(object):
         520: ServerError,
         522: ServerError,
     }
-    SUCCESS_STATUSES = {codes["created"], codes["ok"]}
+    SUCCESS_STATUSES = {codes["accepted"], codes["created"], codes["ok"]}
 
     @staticmethod
     def _log_request(data, method, params, url):

--- a/tests/cassettes/Authorizer_revoke__access_token_with_refresh_set.json
+++ b/tests/cassettes/Authorizer_revoke__access_token_with_refresh_set.json
@@ -1,46 +1,98 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-07-09T22:26:13",
+      "recorded_at": "2021-06-07T11:40:17",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "grant_type=refresh_token&refresh_token=<REFRESH_TOKEN>"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "74",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore:test (by /u/bboe) prawcore/0.0.8"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "78"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=546C0rA0lZHlHLA00s"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/access_token"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAAyXMsQrCMBSF4VcJd+4QEFTcdHBUC4VClxCTA70tJOUmlgbx3SW6fvznvMk6h5RMjjMCnRTN/dAfh8ehnYxtp6tdL7J1r/Po75oaRb/O5LKgxk9YgVT3WNnBsK98iwEVsS0sSIbr826vdaMoufjfjpxylKLYI2TORQmsp88X6VXzg5IAAAA=",
           "encoding": "UTF-8",
-          "string": ""
+          "string": "{\"access_token\": \"1234678-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"refresh_token\": \"1234678-111111111111111111111111111111\", \"scope\": \"identity\"}"
         },
         "headers": {
-          "CF-RAY": "2bff324294db2963-DUB",
-          "Connection": "keep-alive",
-          "Content-Encoding": "gzip",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 09 Jul 2016 22:26:13 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "Transfer-Encoding": "chunked",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "set-cookie": "loid=S1UX7gEWPLHZFXDMKZ; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 09-Jul-2018 22:26:13 GMT; secure",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "184"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 11:40:17 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "583"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
           "code": 200,
@@ -50,21 +102,37 @@
       }
     },
     {
-      "recorded_at": "2016-07-09T22:26:13",
+      "recorded_at": "2021-06-07T11:40:17",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "token=kWZW8ZP7Qj_aQjFavBrxTuAhdO0&token_type_hint=access_token"
+          "string": "token=1234678-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&token_type_hint=access_token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "62",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "loid=S1UX7gEWPLHZFXDMKZ; loidcreated=2016-07-09T22%3A26%3A13.585Z; __cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore:test (by /u/bboe) prawcore/0.0.8"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "74"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=546C0rA0lZHlHLA00s"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -75,66 +143,158 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "2bff324364eb2963-DUB",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 09 Jul 2016 22:26:13 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 11:40:18 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298"
+          ],
+          "x-ratelimit-reset": [
+            "582"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     },
     {
-      "recorded_at": "2016-07-09T22:26:14",
+      "recorded_at": "2021-06-07T11:40:17",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "grant_type=refresh_token&refresh_token=<REFRESH_TOKEN>"
+          "string": "grant_type=refresh_token&refresh_token=1234678-111111111111111111111111111111"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "74",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "loid=S1UX7gEWPLHZFXDMKZ; loidcreated=2016-07-09T22%3A26%3A13.585Z; __cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore:test (by /u/bboe) prawcore/0.0.8"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "78"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=546C0rA0lZHlHLA00s"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/access_token"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAAyXMywrCMBCF4VcJs+6iIIi6dW3VKl5WISYHOghJmQTbQXx3iW4//nPe5LxHzrakJyJtDG1vBz2turVTvc7ny31/7HUYpp1MnhpDv84WHVHjB5xAqge82MNyqNyliIqYRxZky/V5sWzbxlD26b8dOJckajggFi5qBC7Q5wtT2GygkgAAAA==",
           "encoding": "UTF-8",
-          "string": ""
+          "string": "{\"access_token\": \"12345678-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"refresh_token\": \"12345678-222222222222222222222222222222\", \"scope\": \"identity\"}"
         },
         "headers": {
-          "CF-RAY": "2bff3245e5052963-DUB",
-          "Connection": "keep-alive",
-          "Content-Encoding": "gzip",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 09 Jul 2016 22:26:14 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "Transfer-Encoding": "chunked",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "184"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 11:40:18 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297"
+          ],
+          "x-ratelimit-reset": [
+            "582"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
           "code": 200,
@@ -144,5 +304,5 @@
       }
     }
   ],
-  "recorded_with": "betamax/0.7.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/cassettes/Authorizer_revoke__access_token_without_refresh_set.json
+++ b/tests/cassettes/Authorizer_revoke__access_token_without_refresh_set.json
@@ -1,45 +1,98 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-02-14T23:49:47",
+      "recorded_at": "2021-06-07T10:30:40",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "code=<TEMP_CODE>&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A8080"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "105",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "108"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=f5KZ6I9GmO6zC9InB3; loid=0000000000cksuire2.2.1623058268671.Z0FBQUFBQmd2ZWRjZ3VXVUluMld4VXBuVFNpVUtmdUo5Qmlac0xqQmw4RnNaNzZkN3RGcW9SMzVDTWJTUW81OFVtME9rcW5yak5iX3djdXVDNDk5Znl1clZkdERSM1EyR2NFQUlKbUFldVlWSVhDRTRHVUpwT3cxTW1tSXhfbWUxRTFiWldBc29LaFo; session_tracker=whsHxMuMAvrj45AdCl.0.1623058268671.Z0FBQUFBQmd2ZWRjSWVNelA3U1Z6elpFUGJSc3l5X3ktZHlUdFRmbkhidGpFYmhOYnZ4UHlxRzdOM0p6a0dsOEFiY3NBcjBZN0JoMWc5TTBiU3Jmb1NHcFpTLTJtSEhiZjRELVdYb0tRMFNvNUFlU053SHZ2eUkwdGFZWjkzZ2s4WDJrZmxvcE96R20"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/access_token"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI3NjCyMDPXDXFOcinOCPAz9SwPdo0vKsg3NXKyzE91jDD2VdJRUAKrjy+pLEgFaUpKTSxKLQKJp1YUZBalFsdnggwzNjMw0FFQKk7OhyjLTEnNK8ksqVSqBQBlFVapeAAAAA==",
           "encoding": "UTF-8",
-          "string": ""
+          "string": "{\"access_token\": \"1234678-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"identity\"}"
         },
         "headers": {
-          "CF-RAY": "274cabe9e92639b8-PHX",
-          "Connection": "keep-alive",
-          "Content-Encoding": "gzip",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 23:49:47 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "Transfer-Encoding": "chunked",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "124"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 10:30:40 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "560"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
           "code": 200,
@@ -49,21 +102,37 @@
       }
     },
     {
-      "recorded_at": "2016-02-14T23:49:47",
+      "recorded_at": "2021-06-07T10:30:40",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "token=7302867-TCbDshPN5IwSE_rpo52B9oeAX3M&token_type_hint=access_token"
+          "string": "token=1234678-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&token_type_hint=access_token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "70",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "74"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=f5KZ6I9GmO6zC9InB3; loid=0000000000cksuire2.2.1623058268671.Z0FBQUFBQmd2ZWRjZ3VXVUluMld4VXBuVFNpVUtmdUo5Qmlac0xqQmw4RnNaNzZkN3RGcW9SMzVDTWJTUW81OFVtME9rcW5yak5iX3djdXVDNDk5Znl1clZkdERSM1EyR2NFQUlKbUFldVlWSVhDRTRHVUpwT3cxTW1tSXhfbWUxRTFiWldBc29LaFo; session_tracker=whsHxMuMAvrj45AdCl.0.1623058268671.Z0FBQUFBQmd2ZWRjSWVNelA3U1Z6elpFUGJSc3l5X3ktZHlUdFRmbkhidGpFYmhOYnZ4UHlxRzdOM0p6a0dsOEFiY3NBcjBZN0JoMWc5TTBiU3Jmb1NHcFpTLTJtSEhiZjRELVdYb0tRMFNvNUFlU053SHZ2eUkwdGFZWjkzZ2s4WDJrZmxvcE96R20"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -74,26 +143,65 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "274cabeab92839b8-PHX",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 23:49:47 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 10:30:40 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298"
+          ],
+          "x-ratelimit-reset": [
+            "560"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     }
   ],
-  "recorded_with": "betamax/0.5.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/cassettes/Authorizer_revoke__refresh_token_with_access_set.json
+++ b/tests/cassettes/Authorizer_revoke__refresh_token_with_access_set.json
@@ -1,45 +1,98 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-02-14T23:37:35",
+      "recorded_at": "2021-06-07T10:05:14",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "grant_type=refresh_token&refresh_token=<REFRESH_TOKEN>"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "74",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "78"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=whsHxMuMAvrj45AdCl; loid=0000000000cksuire2.2.1623058268671.Z0FBQUFBQmd2ZWRjZ3VXVUluMld4VXBuVFNpVUtmdUo5Qmlac0xqQmw4RnNaNzZkN3RGcW9SMzVDTWJTUW81OFVtME9rcW5yak5iX3djdXVDNDk5Znl1clZkdERSM1EyR2NFQUlKbUFldVlWSVhDRTRHVUpwT3cxTW1tSXhfbWUxRTFiWldBc29LaFo; session_tracker=oqrOtPMaeBQGm531fr.0.1623058268671.Z0FBQUFBQmd2ZWRjSWVNelA3U1Z6elpFUGJSc3l5X3ktZHlUdFRmbkhidGpFYmhOYnZ4UHlxRzdOM0p6a0dsOEFiY3NBcjBZN0JoMWc5TTBiU3Jmb1NHcFpTLTJtSEhiZjRELVdYb0tRMFNvNUFlU053SHZ2eUkwdGFZWjkzZ2s4WDJrZmxvcE96R20"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/access_token"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUDI3NjCyMDPX1S2JcClz9QwyCHfLrkytcNL1CU4MD3RKMzZLV9JRUAKrjy+pLEgFaUpKTSxKLQKJp1YUZBalFsdnggwzNjMw0FFQKk7OhyjLTEnNK8ksqVSqBQBiDDtjeAAAAA==",
           "encoding": "UTF-8",
-          "string": ""
+          "string": "{\"access_token\": \"1234678-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"refresh_token\": \"1234678-111111111111111111111111111111\", \"scope\": \"identity\"}"
         },
         "headers": {
-          "CF-RAY": "274c9a0c907e39e8-PHX",
-          "Connection": "keep-alive",
-          "Content-Encoding": "gzip",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 23:37:35 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "Transfer-Encoding": "chunked",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "184"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 10:05:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298"
+          ],
+          "x-ratelimit-reset": [
+            "286"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
           "code": 200,
@@ -49,21 +102,37 @@
       }
     },
     {
-      "recorded_at": "2016-02-14T23:37:35",
+      "recorded_at": "2021-06-07T10:05:14",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "token=<REFRESH_TOKEN>&token_type_hint=refresh_token"
+          "string": "token=1234678-111111111111111111111111111111&token_type_hint=refresh_token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "71",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "75"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=f5KZ6I9GmO6zC9InB3; loid=0000000000cksuire2.2.1623058268671.Z0FBQUFBQmd2ZWRjZ3VXVUluMld4VXBuVFNpVUtmdUo5Qmlac0xqQmw4RnNaNzZkN3RGcW9SMzVDTWJTUW81OFVtME9rcW5yak5iX3djdXVDNDk5Znl1clZkdERSM1EyR2NFQUlKbUFldVlWSVhDRTRHVUpwT3cxTW1tSXhfbWUxRTFiWldBc29LaFo; session_tracker=oqrOtPMaeBQGm531fr.0.1623058268671.Z0FBQUFBQmd2ZWRjSWVNelA3U1Z6elpFUGJSc3l5X3ktZHlUdFRmbkhidGpFYmhOYnZ4UHlxRzdOM0p6a0dsOEFiY3NBcjBZN0JoMWc5TTBiU3Jmb1NHcFpTLTJtSEhiZjRELVdYb0tRMFNvNUFlU053SHZ2eUkwdGFZWjkzZ2s4WDJrZmxvcE96R20"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -74,26 +143,65 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "274c9a0d408239e8-PHX",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 23:37:35 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 10:05:15 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297"
+          ],
+          "x-ratelimit-reset": [
+            "285"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     }
   ],
-  "recorded_with": "betamax/0.5.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/cassettes/Authorizer_revoke__refresh_token_without_access_set.json
+++ b/tests/cassettes/Authorizer_revoke__refresh_token_without_access_set.json
@@ -1,21 +1,37 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-02-14T23:34:34",
+      "recorded_at": "2021-06-07T09:31:09",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "token=<REFRESH_TOKEN>&token_type_hint=refresh_token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "71",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=dd555eb868b1bcfd517d08fcb174c3afc1454806972",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=whsHxMuMAvrj45AdCl; loid=0000000000cksuire2.2.1623058268671.Z0FBQUFBQmd2ZWRjZ3VXVUluMld4VXBuVFNpVUtmdUo5Qmlac0xqQmw4RnNaNzZkN3RGcW9SMzVDTWJTUW81OFVtME9rcW5yak5iX3djdXVDNDk5Znl1clZkdERSM1EyR2NFQUlKbUFldVlWSVhDRTRHVUpwT3cxTW1tSXhfbWUxRTFiWldBc29LaFo; session_tracker=whsHxMuMAvrj45AdCl.0.1623058269105.Z0FBQUFBQmd2ZWRjSWVNelA3U1Z6elpFUGJSc3l5X3ktZHlUdFRmbkhidGpFYmhOYnZ4UHlxRzdOM0p6a0dsOEFiY3NBcjBZN0JoMWc5TTBiU3Jmb1NHcFpTLTJtSEhiZjRELVdYb0tRMFNvNUFlU053SHZ2eUkwdGFZWjkzZ2s4WDJrZmxvcE96R20"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -26,26 +42,65 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "274c959f39d63982-PHX",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 23:34:34 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 09:31:09 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "293"
+          ],
+          "x-ratelimit-reset": [
+            "531"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     }
   ],
-  "recorded_with": "betamax/0.5.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/cassettes/Session_request__accepted.json
+++ b/tests/cassettes/Session_request__accepted.json
@@ -1,0 +1,214 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-06-09T23:00:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "152"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.1.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"00000000-000000000000000000000000000000\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "117"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 09 Jun 2021 23:00:17 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=KLG8DuWl7lo6rq6Dzq; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "583"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-06-09T23:00:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer 00000000-000000000000000000000000000000"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Cookie": [
+            "edgebucket=KLG8DuWl7lo6rq6Dzq"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.1.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/read_all_messages?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 09 Jun 2021 23:00:18 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "redesign_optout=true; Domain=reddit.com; Max-Age=94607999; Path=/; expires=Sat, 08-Jun-2024 23:00:18 GMT; secure",
+            "session_tracker=6GEhiIYy1IKboYp6F8.0.1623279618070.Z0FBQUFBQmd3VWdDcW5WVsk0UE5Dc2JJME1QaG5ncDdfTDgtOTRtWWxxLXJmWWFsS0NaaWdrvzRkQmJnbEhIUkYzcm9FNGlHN1p6N3ZoODM3cTliWDRseFNwTDBYSHNdWE15Wkhvc1VCVW1zUU81cVFmYy1wbW5tRG9aUkU4Q1FlQTBTemdRSTA2Y0s; Domain=reddit.com; Max-Age=7199; Path=/; expires=Thu, 10-Jun-2021 01:00:18 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "582"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 202,
+          "message": "Accepted"
+        },
+        "url": "https://oauth.reddit.com/api/read_all_messages?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/cassettes/TrustedAuthenticator_revoke_token.json
+++ b/tests/cassettes/TrustedAuthenticator_revoke_token.json
@@ -1,20 +1,34 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-02-14T22:51:31",
+      "recorded_at": "2021-06-07T09:30:24",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "token=dummy+token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "17",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "17"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -25,27 +39,68 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "274c568ed95939e8-PHX",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 22:51:31 GMT",
-          "Server": "cloudflare-nginx",
-          "Set-Cookie": "__cfduid=d606bb08abab5495ec27d11011454bcfa1455490291; expires=Mon, 13-Feb-17 22:51:31 GMT; path=/; domain=.reddit.com; HttpOnly",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 09:30:24 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=hhWRRZiFFiiGuzWIo9; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "576"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     }
   ],
-  "recorded_with": "betamax/0.5.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/cassettes/TrustedAuthenticator_revoke_token__with_access_token_hint.json
+++ b/tests/cassettes/TrustedAuthenticator_revoke_token__with_access_token_hint.json
@@ -1,21 +1,37 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-02-14T22:51:31",
+      "recorded_at": "2021-06-07T09:30:24",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "token=dummy+token&token_type_hint=access_token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "46",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=d606bb08abab5495ec27d11011454bcfa1455490291",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "46"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=S3wlJDCxzOhDOBJEN2"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -26,26 +42,65 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "274c568f896239e8-PHX",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 22:51:31 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 09:30:25 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298"
+          ],
+          "x-ratelimit-reset": [
+            "575"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     }
   ],
-  "recorded_with": "betamax/0.5.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/cassettes/TrustedAuthenticator_revoke_token__with_refresh_token_hint.json
+++ b/tests/cassettes/TrustedAuthenticator_revoke_token__with_refresh_token_hint.json
@@ -1,21 +1,37 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-02-14T22:51:31",
+      "recorded_at": "2021-06-07T09:30:24",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "token=dummy+token&token_type_hint=refresh_token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic <BASIC_AUTH>",
-          "Connection": "keep-alive",
-          "Content-Length": "47",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=d606bb08abab5495ec27d11011454bcfa1455490291",
-          "User-Agent": "prawcore/0.0.1a1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "47"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=k0a87qutnOD8PfGB2w"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -26,26 +42,65 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "274c5690796e39e8-PHX",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 14 Feb 2016 22:51:31 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 09:30:25 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "297"
+          ],
+          "x-ratelimit-reset": [
+            "575"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     }
   ],
-  "recorded_with": "betamax/0.5.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/cassettes/UntrustedAuthenticator_revoke_token.json
+++ b/tests/cassettes/UntrustedAuthenticator_revoke_token.json
@@ -1,21 +1,34 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-08-08T15:16:56",
+      "recorded_at": "2021-06-07T09:26:10",
       "request": {
         "body": {
           "encoding": "utf-8",
           "string": "token=dummy+token"
         },
         "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Authorization": "Basic N3poaE9NdGNPQUlxU2c6",
-          "Connection": "keep-alive",
-          "Content-Length": "17",
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=d606bb08abab5495ec27d11011454bcfa1455490291",
-          "User-Agent": "prawcore:test (by /u/bboe) prawcore/0.2.1"
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "17"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.0.0"
+          ]
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/revoke_token"
@@ -26,26 +39,68 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "2cf3eea58337142b-LAX",
-          "Connection": "keep-alive",
-          "Content-Length": "0",
-          "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Mon, 08 Aug 2016 15:16:55 GMT",
-          "Server": "cloudflare-nginx",
-          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "X-Moose": "majestic",
-          "cache-control": "max-age=0, must-revalidate",
-          "x-content-type-options": "nosniff",
-          "x-frame-options": "SAMEORIGIN",
-          "x-xss-protection": "1; mode=block"
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 07 Jun 2021 09:26:10 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=0myJx5ttzvTVXbZNwZ; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "230"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
         },
         "status": {
-          "code": 204,
-          "message": "No Content"
+          "code": 200,
+          "message": "OK"
         },
         "url": "https://www.reddit.com/api/v1/revoke_token"
       }
     }
   ],
-  "recorded_with": "betamax/0.7.1"
+  "recorded_with": "betamax/0.8.1"
 }

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -89,6 +89,15 @@ class SessionTest(unittest.TestCase):
         authorizer = prawcore.ImplicitAuthorizer(authenticator, None, 0, "")
         prawcore.Session(authorizer)
 
+    def test_request__accepted(self):
+        with Betamax(REQUESTOR).use_cassette("Session_request__accepted"):
+            session = prawcore.Session(script_authorizer())
+            with LogCapture(level=logging.DEBUG) as log_capture:
+                session.request("POST", "api/read_all_messages")
+            log_capture.check_present(
+                ("prawcore", "DEBUG", "Response: 202 (2 bytes)")
+            )
+
     @patch("requests.Session")
     def test_request__chunked_encoding_retry(self, mock_session):
         session_instance = mock_session.return_value


### PR DESCRIPTION
## Feature Summary and Justification

Changes success status for token revocation from 204 to 200.

Reddit changed the status code of the response for token revocation attempts that are made with the correct authorization headers (but not necessarily the right token) from 204 to 200, presumably to be RFC 7009 [compliant](https://datatracker.ietf.org/doc/html/rfc7009/#section-2.2). The only thing from an employee I could find on redditdev about this was [this comment](https://www.reddit.com/r/redditdev/comments/jl232s/help_did_something_change_with_the_authentication/gamoyky/).

This doesn't affect prawcore's ability to revoke a token, but it does create an unfortunate bug. Because prawcore sees a 200 instead of a 204, it throws a response exception before it can clear the token. Fortunately, the next request results in a 401 (because the token is now invalid), which makes prawcore clear the token and refresh the access token.

There is a much bigger issue here regarding refresh tokens that I discovered while running tests. Right now, after you authorize a code, you're given an initial refresh token, which I'll call token_0. When you use refresh token 0, you're given refresh token_1, and when you use refresh token_1, you're given token_2, and so on. They form a list, say `[token_0, token_1, token_2, token_3, ...]`. Every token you're issued remains valid. Even after you use token n, you're allowed use a previous refresh token, token_i, and using that refresh token will get you token_i+1. (The accompanying access tokens are different every time, of course.) The important thing to note is that revoking a refresh token does NOT revoke any other tokens in the list. This means that if a token is leaked, a malicious actor could upgrade it and keep using it before you get a chance to revoke it, or they could keep keep using that token if you don't know which token was leaked, as revoking the future token doesn't revoke the previous one. At present, PRAW's FileToken manager discards the old token without revoking it, and the old refresh_token setting upgrades the token in memory whenever it sees a new refresh token in a response, but doesn't store the upgraded tokens. This leaves a unknown number of still vaild refresh tokens lying around. Of course, you can revoke the tokens by revoking access to the app via prefs/apps/, but this may be somewhat undesirable, as one app can have many refresh tokens of all different kinds of scopes authorized at the same time. I've emailed Reddit and asked them to add an option to revoke all refresh tokens associated with one known refresh token.

## References

* https://www.reddit.com/r/redditdev/comments/jl232s/help_did_something_change_with_the_authentication/gamoyky
* https://www.reddit.com/r/redditdev/comments/kvzaot/oauth2_api_changes_upcoming/
* https://datatracker.ietf.org/doc/html/rfc7009/#section-2.2