### PR TITLE
Add timeout parameter to Requestor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 **Added**
 
 - 301 redirects result in a ``Redirect`` exception.
+- ``Requestor`` is now initialzed with a ``timeout`` parameter.
 
 2.2.0 (2021-06-10)
 ------------------

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -20,6 +20,7 @@ class Requestor(object):
         oauth_url="https://oauth.reddit.com",
         reddit_url="https://www.reddit.com",
         session=None,
+        timeout=TIMEOUT,
     ):
         """Create an instance of the Requestor class.
 
@@ -31,6 +32,8 @@ class Requestor(object):
             (Default: https://www.reddit.com)
         :param session: (Optional) A session to handle requests, compatible with
             requests.Session(). (Default: None)
+        :param timeout: (Optional) How many seconds to wait for the server to send data
+            before giving up. (Default: const.TIMEOUT)
 
         """
         if user_agent is None or len(user_agent) < 7:
@@ -43,14 +46,17 @@ class Requestor(object):
 
         self.oauth_url = oauth_url
         self.reddit_url = reddit_url
+        self.timeout = timeout
 
     def close(self):
         """Call close on the underlying session."""
         return self._http.close()
 
-    def request(self, *args, timeout=TIMEOUT, **kwargs):
+    def request(self, *args, timeout=None, **kwargs):
         """Issue the HTTP request capturing any errors that may occur."""
         try:
-            return self._http.request(*args, timeout=timeout, **kwargs)
+            return self._http.request(
+                *args, timeout=timeout or self.timeout, **kwargs
+            )
         except Exception as exc:
             raise RequestException(exc, args, kwargs)

--- a/tests/test_requestor.py
+++ b/tests/test_requestor.py
@@ -1,6 +1,7 @@
 """Test for prawcore.requestor.Requestor class."""
 import pickle
 import unittest
+from inspect import signature
 
 from mock import Mock, patch
 
@@ -59,6 +60,13 @@ class RequestorTest(unittest.TestCase):
         )
 
         self.assertEqual(requestor.request("https://reddit.com"), override)
+
+    def test_request__session_timeout_default(self):
+        requestor = prawcore.Requestor("prawcore:test (by /u/bboe)")
+        requestor_signature = signature(requestor._http.request)
+        self.assertEqual(
+            str(requestor_signature.parameters["timeout"]), "timeout=None"
+        )
 
     def test_pickle(self):
         requestor = prawcore.Requestor("prawcore:test (by /u/bboe)")


### PR DESCRIPTION
## Feature Summary and Justification

Adds a timeout parameter to the Requestor class. Once this is done, the corresponding PRAW change is just adding the line ` self.config.timeout,` to [Reddit. _prepare_prawcore](https://github.com/praw-dev/praw/blob/master/praw/reddit.py#L487), so that it becomes

    def _prepare_prawcore(self, requestor_class=None, requestor_kwargs=None):
        requestor_class = requestor_class or Requestor
        requestor_kwargs = requestor_kwargs or {}

        requestor = requestor_class(
            USER_AGENT_FORMAT.format(self.config.user_agent),
            self.config.oauth_url,
            self.config.reddit_url,
            self.config.timeout,
            **requestor_kwargs,
        )

        if self.config.client_secret:
            self._prepare_trusted_prawcore(requestor)
        else:
            self._prepare_untrusted_prawcore(requestor)

You could also convert timeout to a [float](https://github.com/praw-dev/praw/blob/master/praw/config.py#L163).

As written, there are now two different timeout values you can set from PRAW (after a corresponding PR), which are equal when praw.Reddit is initialized. If `reddit=praw.Reddit()`, the timeout value for special tasks like obtaining and revoking tokens can be set with `reddit._core._requestor.timeout` , and the timeout value for everything else is set with `reddit.config.timeout`, just as it is now.

## References

* https://github.com/praw-dev/prawcore/issues/114#issuecomment-859230112