### PR TITLE
Raise Redirect exception on 301 HTTP responses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Change Log
 
 prawcore follows `semantic versioning <http://semver.org/>`_.
 
+Unreleased
+----------
+
+**Added**
+
+- 301 redirects result in a ``Redirect`` exception.
+
 2.2.0 (2021-06-10)
 ------------------
 
@@ -21,7 +28,7 @@ prawcore follows `semantic versioning <http://semver.org/>`_.
 **Added**
 
 - Add a ``URITooLarge`` exception.
-- :class:`.ScriptAuthorizer` has a new parameter ``two_factor_callback `` that supplies
+- :class:`.ScriptAuthorizer` has a new parameter ``two_factor_callback`` that supplies
   OTPs (One-Time Passcodes) when :meth:`.ScriptAuthorizer.refresh` is called.
 - Add a ``TooManyRequests`` exception.
 

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -100,6 +100,7 @@ class Session(object):
         codes["gateway_timeout"]: ServerError,
         codes["internal_server_error"]: ServerError,
         codes["media_type"]: SpecialError,
+        codes["moved_permanently"]: Redirect,
         codes["not_found"]: NotFound,
         codes["request_entity_too_large"]: TooLarge,
         codes["request_uri_too_large"]: URITooLong,

--- a/tests/cassettes/Session_request__redirect_301.json
+++ b/tests/cassettes/Session_request__redirect_301.json
@@ -1,0 +1,193 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-06-30T00:09:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=p22PHVNAjmhSSmzLXS; loid=eRSV4OpMHfrI9sSU2d; redesign_optout=true; session_tracker=YaCPCgCQQP8Q53XnHF.0.1588120953197.Z0FBQUFBQmVxTTE1Tzd0eUxURl9ZZnlDbHAxedVJX19CNXhMOEVGaWh6cWthMUlGZDFMamVfZWdOYlVnemljTEs0cWttMFVxTXR4bUYyMzhXai0tY0RYckd4OGwINEF6dHpDabtqZDVXckd49TdxU1VrUWx1T1VOdzEtSldwWDU2oW5odlBiM1VYTkc"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.2.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"-000000000000000000000000000000\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "109"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 30 Jun 2021 00:09:45 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "15"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-loid": [
+            "0000000000d0lnaiza.2.1625011785709.Z0FBQUFBQmcyN1pKNTJ2SHN0STZIQnlTb3JQTGR0RXRBYmpTTDZOdUw1SE9QYlNZRWNkcHVpQUcyS2dJbFhsYnp4b1wkRzVKR0gxQ25BSDhMNkpBZkp6XzF4MUM3M0JsMlNNV0F690MxRVFWQ3rRLXBkNkpwVkpTOFpJY2dZMWJtSlVlVkVWV1FYaUE"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-06-30T00:09:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer -000000000000000000000000000000"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=p22PHVNAjmhSSmzLXS; loid=eRSV4OpMHfrI9sSU2d; redesign_optout=true; session_tracker=YaCPCgCQQP8Q53XnHF.0.1588120953197.Z0FBQUFBQmVxTTE1Tzd0eUxURl9ZZnlDbHAxedVJX19CNXhMOEVGaWh6cWthMUlGZDFMamVfZWdOYlVnemljTEs0cWttMFVxTXR4bUYyMzhXai0tY0RYckd4OGwINEF6dHpDabtqZDVXckd49TdxU1VrUWx1T1VOdzEtSldwWDU2oW5odlBiM1VYTkc"
+          ],
+          "User-Agent": [
+            "prawcore:test (by /u/bboe) prawcore/2.2.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/t/bird?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "text/html; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 30 Jun 2021 00:09:45 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "loid=eRSV4OpMHfrI9sSU2d; Max-Age=63072000; Path=/; Domain=.reddit.com; SameSite=None; Secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "location": [
+            "https://oauth.reddit.com/r/t:bird/"
+          ]
+        },
+        "status": {
+          "code": 301,
+          "message": "Moved Permanently"
+        },
+        "url": "https://oauth.reddit.com/t/bird?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -405,6 +405,13 @@ class SessionTest(unittest.TestCase):
                 session.request("GET", "/r/random")
             self.assertTrue(context_manager.exception.path.startswith("/r/"))
 
+    def test_request__redirect_301(self):
+        with Betamax(REQUESTOR).use_cassette("Session_request__redirect_301"):
+            session = prawcore.Session(readonly_authorizer())
+            with self.assertRaises(prawcore.Redirect) as context_manager:
+                session.request("GET", "t/bird")
+            self.assertTrue(context_manager.exception.path == "/r/t:bird/")
+
     def test_request__service_unavailable(self):
         with Betamax(REQUESTOR).use_cassette(
             "Session_request__service_unavailable"


### PR DESCRIPTION
## Feature Summary and Justification

Reddit has a feature called "topics", which have addresses that look like this: `https://www.reddit.com/t/animals_and_pets/` . These pages are inaccessible from the API: attempting to get `https://oauth.reddit.com/t/animals_and_pets/` results in a redirect to `https://oauth.reddit.com/r/t:animals_and_pets/`. Following that latter link results in a 404 (go figure). I added 301s to the list of status exceptions.

This change does not need a test to ensure 100% code coverage, but I added one in case it is wanted.