### PR TITLE
Provide option to retry calls to ScriptAuthorizer.refresh

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 - ``Requestor`` is now initialzed with a ``timeout`` parameter.
 - ``ScriptAuthorizer``, ``ReadOnlyAuthorizer``, and ``DeviceIDAuthorizer`` have a
   new parameter, ``scopes``, which determines the scope of access requests.
+- ``ScriptAuthorizer.refresh`` can now retry authorization attempts that raise
+  instances of ``OAuthException``.
 
 2.2.0 (2021-06-10)
 ------------------


### PR DESCRIPTION
## Feature Summary and Justification

The password flow with 2fa has two circumstances under which it is desirable to retry (or more accurately, re-do) an authorization attempt that results in an invalid grant. The first case is the one where a user accidentally enters the wrong OTP. Instead of immediately raising an OAuthException, which would be inconvenient in the middle of a batch request, it would be helpful to let the user try again. The second case is the one where a user supplies all of the right credentials, but authorizes at the wrong time. Reddit doesn't allow the same OTP to be used to obtain two access tokens, as a security precaution against the code being intercepted. It would be helpful if there was an option to re-do the authorization request after a delay.

The proposed solution is to let the two factor callback return the otp as either a string or a 3-tuple of the form `(<OTP>, <DELAY>, <TRIES>)`, and to change `ScriptAuthorizer.refresh` accordingly. Prawcore would use then use the form of the OTP to determine if and how to re-do attempts to refresh the authorization when it encounters an OAuthException.

I have a PR ready to close the PRAW PR, and it could proceed without this change, but this would make things easier.