### PR TITLE
Revert "Release v2.4.0"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,6 @@ prawcore follows `semantic versioning <http://semver.org/>`_.
 Unreleased
 ----------
 
-2.4.0 (2023/10/01)
-------------------
-
-2.4.0 (2023/10/01)
-------------------
-
 **Changed**
 
 - Drop support for Python 3.6, which is end-of-life on 2021-12-23.

--- a/prawcore/const.py
+++ b/prawcore/const.py
@@ -1,7 +1,7 @@
 """Constants for the prawcore package."""
 import os
 
-__version__ = "2.4.1.dev0"
+__version__ = "2.3.0"
 
 ACCESS_TOKEN_PATH = "/api/v1/access_token"  # noqa: S105
 AUTHORIZATION_PATH = "/api/v1/authorize"  # noqa: S105


### PR DESCRIPTION
Should be the last time. There was a broken version specifier.