### PR TITLE
Move version from const.py to __init__.py for Flit static introspection

### DIFF
--- a/prawcore/__init__.py
+++ b/prawcore/__init__.py
@@ -11,9 +11,10 @@ from .auth import (
     TrustedAuthenticator,
     UntrustedAuthenticator,
 )
-from .const import __version__
 from .exceptions import *  # noqa: F403
 from .requestor import Requestor
 from .sessions import Session, session
 
 logging.getLogger(__package__).addHandler(logging.NullHandler())
+
+__version__ = "2.4.1.dev0"

--- a/prawcore/const.py
+++ b/prawcore/const.py
@@ -1,8 +1,6 @@
 """Constants for the prawcore package."""
 import os
 
-__version__ = "2.4.1.dev0"
-
 ACCESS_TOKEN_PATH = "/api/v1/access_token"  # noqa: S105
 AUTHORIZATION_PATH = "/api/v1/authorize"  # noqa: S105
 REVOKE_TOKEN_PATH = "/api/v1/revoke_token"  # noqa: S105

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 import requests
 
-import prawcore
-
 from .const import TIMEOUT
 from .exceptions import InvalidInvocation, RequestException
 
@@ -47,14 +45,15 @@ class Requestor:
             giving up (default: ``prawcore.const.TIMEOUT``).
 
         """
+        # Imported locally to avoid an import cycle, with __init__
+        from . import __version__
+
         if user_agent is None or len(user_agent) < 7:
             msg = "user_agent is not descriptive"
             raise InvalidInvocation(msg)
 
         self._http = session or requests.Session()
-        self._http.headers[
-            "User-Agent"
-        ] = f"{user_agent} prawcore/{prawcore.__version__}"
+        self._http.headers["User-Agent"] = f"{user_agent} prawcore/{__version__}"
 
         self.oauth_url = oauth_url
         self.reddit_url = reddit_url

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING, Any
 
 import requests
 
-from .const import TIMEOUT, __version__
+import prawcore
+
+from .const import TIMEOUT
 from .exceptions import InvalidInvocation, RequestException
 
 if TYPE_CHECKING:
@@ -50,7 +52,9 @@ class Requestor:
             raise InvalidInvocation(msg)
 
         self._http = session or requests.Session()
-        self._http.headers["User-Agent"] = f"{user_agent} prawcore/{__version__}"
+        self._http.headers[
+            "User-Agent"
+        ] = f"{user_agent} prawcore/{prawcore.__version__}"
 
         self.oauth_url = oauth_url
         self.reddit_url = reddit_url

--- a/tools/set_version.py
+++ b/tools/set_version.py
@@ -41,7 +41,7 @@ def handle_version(version):
 
 
 def increment_development_version():
-    with open("prawcore/const.py") as fp:
+    with open("prawcore/__init__.py") as fp:
         version = re.search('__version__ = "([^"]+)"', fp.read()).group(1)
 
     parsed_version = valid_version(version)
@@ -89,7 +89,7 @@ def update_changelog(version):
 
 
 def update_package(version):
-    with open("prawcore/const.py") as fp:
+    with open("prawcore/__init__.py") as fp:
         content = fp.read()
 
     updated = re.sub('__version__ = "([^"]+)"', f'__version__ = "{version}"', content)
@@ -97,7 +97,7 @@ def update_package(version):
         sys.stderr.write("Package version string not changed\n")
         return False
 
-    with open("prawcore/const.py", "w") as fp:
+    with open("prawcore/__init__.py", "w") as fp:
         fp.write(updated)
 
     print(version)


### PR DESCRIPTION
As discussed in #164 , moving `__version__` from `const.py` to be directly in `__init__,py` allows Flit to statically introspect it, preventing `requests` from being required as an unspecified, implict build-time dependency, causing build/install failures in certain scenarios. I've tested and confirmed locally that this fix allows successfully building and installing `prawcore` without having `requests` in the local environment.

Additionally, I've updated the one internal module using this value from `const.py` to use that from `__init__.py`. I did have to switch from a relative `from` import to an absolute import to avoid an import cycle error; alternatively, I could also move the import to be inside the relevant function, though I figured the former would be more acceptable/less problematic for you—happy to change that as desired.

Finally, I updated the version bump script in `tools/set_version.py` to bump the version in its new location.