### PR TITLE
Sleep for a full second when rate limit is expired with no remaining requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ prawcore follows `semantic versioning <https://semver.org/>`_.
 Unreleased
 ----------
 
+**Fixed**
+
+- Increase half-second delay introduced in ``3.0.0`` to a full second delay.
+
 3.0.0 (2025/01/25)
 ------------------
 

--- a/prawcore/rate_limit.py
+++ b/prawcore/rate_limit.py
@@ -89,7 +89,7 @@ class RateLimiter:
 
         if self.remaining <= 0:
             self.next_request_timestamp_ns = now_ns + max(
-                NANOSECONDS / 2, seconds_to_reset * NANOSECONDS
+                NANOSECONDS, seconds_to_reset * NANOSECONDS
             )
             return
 

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -121,7 +121,7 @@ class TestRateLimiter(UnitTest):
         rate_limiter.update(self._headers(0, 100, 0))
         assert rate_limiter.remaining == 0
         assert rate_limiter.used == 100
-        assert rate_limiter.next_request_timestamp_ns == 37.5 * NANOSECONDS
+        assert rate_limiter.next_request_timestamp_ns == 38 * NANOSECONDS
 
     def test_update__no_change_without_headers(self, rate_limiter):
         prev = copy(rate_limiter)


### PR DESCRIPTION
Should fully resolve https://github.com/praw-dev/prawcore/issues/198