### PR TITLE
Pin astral-sh/setup-uv to commit SHA of v8.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install tox
         run: uv tool install --python-preference only-managed --python ${{ matrix.env }} tox --with tox-uv
       - name: Run test suite


### PR DESCRIPTION
Pins `astral-sh/setup-uv` to the commit SHA of v8.2.0 with a version comment, matching the pinned-ref style used for the other actions. v8 drops floating major tags, requires exact releases (immutable), and v8.2.0 stops sending the GitHub token to the astral.sh download mirror.