### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
             os: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install tox
@@ -40,3 +42,5 @@ on:
   push:
     branches: ["main"]
   pull_request:
+permissions:
+  contents: read

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -2,7 +2,7 @@ jobs:
   pre-commit_autoupdate:
     name: Update pre-commit hooks
     secrets: inherit
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@d982d39c7343205d239f7b8929592f538fb01662 # main 2026-06-06
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -2,7 +2,7 @@ jobs:
   pre-commit_autoupdate:
     name: Update pre-commit hooks
     secrets: inherit
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@main
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@d982d39c7343205d239f7b8929592f538fb01662 # main 2026-06-06
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -2,7 +2,7 @@ jobs:
   prepare_release:
     name: Prepare Release
     secrets: inherit
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@d982d39c7343205d239f7b8929592f538fb01662 # main 2026-06-06
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
     with:
       package: prawcore
       version: ${{ inputs.version }}

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -2,7 +2,7 @@ jobs:
   prepare_release:
     name: Prepare Release
     secrets: inherit
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@main
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@d982d39c7343205d239f7b8929592f538fb01662 # main 2026-06-06
     with:
       package: prawcore
       version: ${{ inputs.version }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -19,7 +21,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 name: Upload Python Package
 on:
   release:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -61,6 +61,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v3.29.5
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -2,7 +2,7 @@ jobs:
   tag_release:
     name: Tag Release
     secrets: inherit
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@d982d39c7343205d239f7b8929592f538fb01662 # main 2026-06-06
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
 name: Tag Release
 on:
   push:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -2,7 +2,7 @@ jobs:
   tag_release:
     name: Tag Release
     secrets: inherit
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@main
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@d982d39c7343205d239f7b8929592f538fb01662 # main 2026-06-06
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
Follow-ups from a security review of the workflow files:

- **Restrict CI token**: add `permissions: contents: read` to ci.yml so PR-triggered jobs no longer receive a write-scoped `GITHUB_TOKEN` (the repo default is currently write).
- **Don't persist credentials**: `persist-credentials: false` on the ci.yml and pypi.yml checkouts — neither workflow pushes, so the token doesn't need to live in `.git/config`.
- **Pin reusable workflows**: the three `praw-dev/.github` reusable workflows were called at mutable `@main` with `secrets: inherit` (including `SSH_DEPLOY_KEY`); they are now pinned to a commit SHA. Note: that repo has no tags, so dependabot won't bump these — future shared-workflow changes need a manual pin update here.
- **Fix stale pin comments**: the codeql-action SHA is actually v4.36.1 (comment said v3.29.5), and the pypi-publish SHA is exactly v1.14.0 (comment said release/v1).