### PR TITLE
Workflow audit fixes

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          cache: pip
           python-version: 3.x
       - name: Install dependencies
         run: |

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,7 +1,6 @@
 jobs:
   tag_release:
     name: Tag Release
-    secrets: inherit
     uses: praw-dev/.github/.github/workflows/tag_release.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
 name: Tag Release
 on:


### PR DESCRIPTION
Follow-up from auditing praw's workflows (praw-dev/praw#2105) — prawcore had two of the same findings:

- **Drop `cache: pip` from `pypi.yml`**: zizmor flags caching in release-publishing workflows as a cache-poisoning vector; a release build doesn't need the speedup.
- **Remove `secrets: inherit` from `tag_release.yml`**: the shared workflow only uses `GITHUB_TOKEN`, which called workflows receive regardless.