### PR TITLE
Bump shared workflows to v1.1.0 with explicit secrets

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -1,13 +1,14 @@
 jobs:
   pre-commit_autoupdate:
     name: Update pre-commit hooks
-    secrets: inherit
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
 name: Update pre-commit hooks
 on:
   schedule:
     - cron: 0 15 * * 1
   workflow_dispatch:
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,8 +1,10 @@
 jobs:
   prepare_release:
     name: Prepare Release
-    secrets: inherit
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
     with:
       package: prawcore
       version: ${{ inputs.version }}
@@ -16,4 +18,3 @@ on:
         required: true
 permissions:
   contents: read
-  pull-requests: write

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,7 +1,7 @@
 jobs:
   tag_release:
     name: Tag Release
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
The v1.1.0 shared workflows mint a scoped GitHub App token for
create-pull-request instead of using the SSH deploy key, and declare
their secrets via on.workflow_call.secrets, so callers now pass APP_ID
and APP_PRIVATE_KEY explicitly instead of 'secrets: inherit'. Caller
permissions drop to contents: read since the App token does the
writing.
