### PR TITLE
Bump shared workflows to v1.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: praw-dev/.github/.github/workflows/ci.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/ci.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
     with:
       min_python: "3.10"
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
     with:
       package: prawcore
       version: ${{ inputs.version }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,7 +1,7 @@
 jobs:
   tag_release:
     name: Tag Release
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
v1.3.2 updates praw-release to v1.2.0, which folds prerelease changelog
sections into the final release section when bumping to a final version.
