### PR TITLE
Add tests for Requestor.request timeout passthrough

### DIFF
--- a/tests/unit/test_requestor.py
+++ b/tests/unit/test_requestor.py
@@ -8,6 +8,7 @@ import pytest
 
 import prawcore
 from prawcore import RequestException
+from prawcore.const import TIMEOUT
 
 from . import UnitTest
 
@@ -29,6 +30,20 @@ class TestRequestor(UnitTest):
     def test_pickle(self, requestor):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
             pickle.loads(pickle.dumps(requestor, protocol=protocol))
+
+    def test_request__default_timeout(self):
+        attrs = {"headers": {}, "request.return_value": "response"}
+        session = Mock(**attrs)
+        requestor = prawcore.Requestor("prawcore:test (by /u/bboe)", session=session)
+        requestor.request("get", "https://reddit.com")
+        assert session.request.call_args.kwargs["timeout"] == TIMEOUT
+
+    def test_request__explicit_timeout(self):
+        attrs = {"headers": {}, "request.return_value": "response"}
+        session = Mock(**attrs)
+        requestor = prawcore.Requestor("prawcore:test (by /u/bboe)", session=session)
+        requestor.request("get", "https://reddit.com", timeout=5)
+        assert session.request.call_args.kwargs["timeout"] == 5
 
     def test_request__session_timeout_default(self, requestor):
         requestor_signature = signature(requestor._http.request)


### PR DESCRIPTION
Adds two unit tests asserting `Requestor.request` actually passes the right `timeout` to the underlying session:

- `test_request__default_timeout` — with no `timeout` argument, the configured default (`prawcore.const.TIMEOUT`) is passed.
- `test_request__explicit_timeout` — an explicit `timeout` argument is passed through unchanged.

Previously only `test_request__session_timeout_default` existed, which inspects the *underlying* `requests.Session.request` signature (a canary that requests itself has no default timeout). That guards the premise behind prawcore's timeout injection but never verifies prawcore's own behavior — line coverage hit `request()` without asserting the value passed. These tests close that behavioral gap.