### PR TITLE
Add type checking improvements and py.typed marker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ prawcore follows `semantic versioning <https://semver.org/>`_.
  Unreleased
 ************
 
+**Added**
+
+- Add an ``__all__`` to the ``prawcore`` package to explicitly define its public API.
+- Add a ``py.typed`` marker (:PEP:`561`) so that downstream projects can type check
+  against prawcore's inline annotations.
+
 ********************
  3.1.0 (2026/06/07)
 ********************

--- a/prawcore/__init__.py
+++ b/prawcore/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from . import exceptions
 from .auth import (
     Authorizer,
     DeviceIDAuthorizer,
@@ -18,3 +19,17 @@ from .sessions import Session, session
 logging.getLogger(__package__).addHandler(logging.NullHandler())
 
 __version__ = "3.1.1.dev0"
+
+__all__ = [
+    "Authorizer",
+    "DeviceIDAuthorizer",
+    "ImplicitAuthorizer",
+    "ReadOnlyAuthorizer",
+    "Requestor",
+    "ScriptAuthorizer",
+    "Session",
+    "TrustedAuthenticator",
+    "UntrustedAuthenticator",
+    "session",
+]
+__all__ += exceptions.__all__

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -125,7 +125,7 @@ class BaseAuthenticator(ABC):
 class BaseAuthorizer:
     """Superclass for OAuth2 authorization tokens and scopes."""
 
-    AUTHENTICATOR_CLASS: tuple | type = BaseAuthenticator
+    AUTHENTICATOR_CLASS: type[BaseAuthenticator] | tuple[type[BaseAuthenticator], ...] = BaseAuthenticator
 
     def __init__(self, authenticator: BaseAuthenticator) -> None:
         """Represent a single authorization to Reddit's API.
@@ -378,7 +378,7 @@ class ScriptAuthorizer(Authorizer):
         authenticator: BaseAuthenticator,
         username: str | None,
         password: str | None,
-        two_factor_callback: Callable | None = None,
+        two_factor_callback: Callable[[], str] | None = None,
         scopes: list[str] | None = None,
     ) -> None:
         """Represent a single personal-use authorization to Reddit's API.

--- a/prawcore/exceptions.py
+++ b/prawcore/exceptions.py
@@ -8,6 +8,28 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     from requests.models import Response
 
+__all__ = [
+    "BadJSON",
+    "BadRequest",
+    "Conflict",
+    "Forbidden",
+    "InsufficientScope",
+    "InvalidInvocation",
+    "InvalidToken",
+    "NotFound",
+    "OAuthException",
+    "PrawcoreException",
+    "Redirect",
+    "RequestException",
+    "ResponseException",
+    "ServerError",
+    "SpecialError",
+    "TooLarge",
+    "TooManyRequests",
+    "URITooLong",
+    "UnavailableForLegalReasons",
+]
+
 
 class PrawcoreException(Exception):  # noqa: N818
     """Base exception class for exceptions that occur within this package."""

--- a/prawcore/requestor.py
+++ b/prawcore/requestor.py
@@ -49,7 +49,11 @@ class Requestor:
         # Imported locally to avoid an import cycle, with __init__
         from . import __version__  # noqa: PLC0415
 
-        if user_agent is None or len(user_agent) < self.MIN_USER_AGENT_LENGTH:
+        # ``user_agent`` is typed ``str``, but validate at runtime for untyped callers.
+        if (
+            not isinstance(user_agent, str)  # pyright: ignore[reportUnnecessaryIsInstance]
+            or len(user_agent) < self.MIN_USER_AGENT_LENGTH
+        ):
             msg = "user_agent is not descriptive"
             raise InvalidInvocation(msg)
 

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -156,7 +156,7 @@ class Session:
         """Allow this object to be used as a context manager."""
         return self
 
-    def __exit__(self, *_args) -> None:
+    def __exit__(self, *_args: object) -> None:
         """Allow this object to be used as a context manager."""
         self.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14"
+  "Programming Language :: Python :: 3.14",
+  "Typing :: Typed"
 ]
 dependencies = [
   "requests>=2.34.2,<3.0"
@@ -52,6 +53,14 @@ requires-python = ">=3.10"
 [project.urls]
 "Issue Tracker" = "https://github.com/praw-dev/prawcore/issues"
 "Source Code" = "https://github.com/praw-dev/prawcore"
+
+[tool.pyright]
+include = ["prawcore"]
+pythonVersion = "3.10"
+# prawcore's authorizer, authenticator, and session classes intentionally share
+# protected members within the package.
+reportPrivateUsage = false
+typeCheckingMode = "strict"
 
 [tool.ruff]
 include = [
@@ -152,7 +161,7 @@ dependency_groups = ["lint"]
 runner = "uv-venv-lock-runner"
 
 [tool.tox.env.type]
-commands = [["pyright", "prawcore"]]
+commands = [["pyright"]]
 dependency_groups = ["type"]
 description = "run type check on code base"
 runner = "uv-venv-lock-runner"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,15 +30,15 @@ def trusted_authenticator(requestor):
     """Return a TrustedAuthenticator instance."""
     return TrustedAuthenticator(
         requestor,
-        pytest.placeholders.client_id,
-        pytest.placeholders.client_secret,
+        placeholders.client_id,
+        placeholders.client_secret,
     )
 
 
 @pytest.fixture
 def untrusted_authenticator(requestor):
     """Return an UntrustedAuthenticator instance."""
-    return UntrustedAuthenticator(requestor, pytest.placeholders.client_id)
+    return UntrustedAuthenticator(requestor, placeholders.client_id)
 
 
 def env_default(key):
@@ -50,17 +50,28 @@ def env_default(key):
 
 
 def pytest_configure(config):
-    pytest.placeholders = Placeholders(placeholders)
     config.addinivalue_line("markers", "cassette_name: Name of cassette to use for test.")
     config.addinivalue_line("markers", "recorder_kwargs: Arguments to pass to the recorder.")
 
 
 class Placeholders:
+    access_token: str
+    basic_auth: str
+    client_id: str
+    client_secret: str
+    password: str
+    permanent_grant_code: str
+    redirect_uri: str
+    refresh_token: str
+    temporary_grant_code: str
+    user_agent: str
+    username: str
+
     def __init__(self, _dict):
         self.__dict__ = _dict
 
 
-placeholders = {
+placeholder_values = {
     x: env_default(x)
     for x in [
         "client_id",
@@ -76,10 +87,12 @@ placeholders = {
 }
 
 if (
-    placeholders["client_id"] != "fake_client_id" and placeholders["client_secret"] == "fake_client_secret"
+    placeholder_values["client_id"] != "fake_client_id" and placeholder_values["client_secret"] == "fake_client_secret"
 ):  # pragma: no cover
-    placeholders["basic_auth"] = b64encode(f"{placeholders['client_id']}:".encode()).decode("utf-8")
+    placeholder_values["basic_auth"] = b64encode(f"{placeholder_values['client_id']}:".encode()).decode("utf-8")
 else:
-    placeholders["basic_auth"] = b64encode(
-        f"{placeholders['client_id']}:{placeholders['client_secret']}".encode(),
+    placeholder_values["basic_auth"] = b64encode(
+        f"{placeholder_values['client_id']}:{placeholder_values['client_secret']}".encode(),
     ).decode("utf-8")
+
+placeholders = Placeholders(placeholder_values)

--- a/tests/integration/test_authenticator.py
+++ b/tests/integration/test_authenticator.py
@@ -1,8 +1,7 @@
 """Test for subclasses of prawcore.auth.BaseAuthenticator class."""
 
-import pytest
-
 import prawcore
+from tests.conftest import placeholders
 
 from . import IntegrationTest
 
@@ -11,29 +10,29 @@ class TestTrustedAuthenticator(IntegrationTest):
     def test_revoke_token(self, requestor):
         authenticator = prawcore.TrustedAuthenticator(
             requestor,
-            pytest.placeholders.client_id,
-            pytest.placeholders.client_secret,
+            placeholders.client_id,
+            placeholders.client_secret,
         )
         authenticator.revoke_token("dummy token")
 
     def test_revoke_token__with_access_token_hint(self, requestor):
         authenticator = prawcore.TrustedAuthenticator(
             requestor,
-            pytest.placeholders.client_id,
-            pytest.placeholders.client_secret,
+            placeholders.client_id,
+            placeholders.client_secret,
         )
         authenticator.revoke_token("dummy token", "access_token")
 
     def test_revoke_token__with_refresh_token_hint(self, requestor):
         authenticator = prawcore.TrustedAuthenticator(
             requestor,
-            pytest.placeholders.client_id,
-            pytest.placeholders.client_secret,
+            placeholders.client_id,
+            placeholders.client_secret,
         )
         authenticator.revoke_token("dummy token", "refresh_token")
 
 
 class TestUntrustedAuthenticator(IntegrationTest):
     def test_revoke_token(self, requestor):
-        authenticator = prawcore.UntrustedAuthenticator(requestor, pytest.placeholders.client_id)
+        authenticator = prawcore.UntrustedAuthenticator(requestor, placeholders.client_id)
         authenticator.revoke_token("dummy token")

--- a/tests/integration/test_authorizer.py
+++ b/tests/integration/test_authorizer.py
@@ -3,22 +3,23 @@
 import pytest
 
 import prawcore
+from tests.conftest import placeholders
 
 from . import IntegrationTest
 
 
 class TestAuthorizer(IntegrationTest):
     def test_authorize__with_invalid_code(self, trusted_authenticator):
-        trusted_authenticator.redirect_uri = pytest.placeholders.redirect_uri
+        trusted_authenticator.redirect_uri = placeholders.redirect_uri
         authorizer = prawcore.Authorizer(trusted_authenticator)
         with pytest.raises(prawcore.OAuthException):
             authorizer.authorize("invalid code")
         assert not authorizer.is_valid()
 
     def test_authorize__with_permanent_grant(self, trusted_authenticator):
-        trusted_authenticator.redirect_uri = pytest.placeholders.redirect_uri
+        trusted_authenticator.redirect_uri = placeholders.redirect_uri
         authorizer = prawcore.Authorizer(trusted_authenticator)
-        authorizer.authorize(pytest.placeholders.permanent_grant_code)
+        authorizer.authorize(placeholders.permanent_grant_code)
 
         assert authorizer.access_token is not None
         assert authorizer.refresh_token is not None
@@ -27,9 +28,9 @@ class TestAuthorizer(IntegrationTest):
         assert authorizer.is_valid()
 
     def test_authorize__with_temporary_grant(self, trusted_authenticator):
-        trusted_authenticator.redirect_uri = pytest.placeholders.redirect_uri
+        trusted_authenticator.redirect_uri = placeholders.redirect_uri
         authorizer = prawcore.Authorizer(trusted_authenticator)
-        authorizer.authorize(pytest.placeholders.temporary_grant_code)
+        authorizer.authorize(placeholders.temporary_grant_code)
 
         assert authorizer.access_token is not None
         assert authorizer.refresh_token is None
@@ -38,7 +39,7 @@ class TestAuthorizer(IntegrationTest):
         assert authorizer.is_valid()
 
     def test_refresh(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=pytest.placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
 
         assert authorizer.access_token is not None
@@ -49,13 +50,13 @@ class TestAuthorizer(IntegrationTest):
     @pytest.mark.cassette_name("TestAuthorizer.test_refresh")
     def test_refresh__post_refresh_callback(self, trusted_authenticator):
         def callback(authorizer):
-            assert authorizer.refresh_token != pytest.placeholders.refresh_token
+            assert authorizer.refresh_token != placeholders.refresh_token
             authorizer.refresh_token = "manually_updated"
 
         authorizer = prawcore.Authorizer(
             trusted_authenticator,
             post_refresh_callback=callback,
-            refresh_token=pytest.placeholders.refresh_token,
+            refresh_token=placeholders.refresh_token,
         )
         authorizer.refresh()
 
@@ -69,7 +70,7 @@ class TestAuthorizer(IntegrationTest):
     def test_refresh__pre_refresh_callback(self, trusted_authenticator):
         def callback(authorizer):
             assert authorizer.refresh_token is None
-            authorizer.refresh_token = pytest.placeholders.refresh_token
+            authorizer.refresh_token = placeholders.refresh_token
 
         authorizer = prawcore.Authorizer(trusted_authenticator, pre_refresh_callback=callback)
         authorizer.refresh()
@@ -86,7 +87,7 @@ class TestAuthorizer(IntegrationTest):
         assert not authorizer.is_valid()
 
     def test_revoke__access_token_with_refresh_set(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=pytest.placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
         authorizer.revoke(only_access=True)
 
@@ -100,9 +101,9 @@ class TestAuthorizer(IntegrationTest):
         assert authorizer.is_valid()
 
     def test_revoke__access_token_without_refresh_set(self, trusted_authenticator):
-        trusted_authenticator.redirect_uri = pytest.placeholders.redirect_uri
+        trusted_authenticator.redirect_uri = placeholders.redirect_uri
         authorizer = prawcore.Authorizer(trusted_authenticator)
-        authorizer.authorize(pytest.placeholders.temporary_grant_code)
+        authorizer.authorize(placeholders.temporary_grant_code)
         authorizer.revoke()
 
         assert authorizer.access_token is None
@@ -111,7 +112,7 @@ class TestAuthorizer(IntegrationTest):
         assert not authorizer.is_valid()
 
     def test_revoke__refresh_token_with_access_set(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=pytest.placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
         authorizer.revoke()
 
@@ -121,7 +122,7 @@ class TestAuthorizer(IntegrationTest):
         assert not authorizer.is_valid()
 
     def test_revoke__refresh_token_without_access_set(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=pytest.placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.revoke()
 
         assert authorizer.access_token is None
@@ -144,8 +145,8 @@ class TestDeviceIDAuthorizer(IntegrationTest):
         authorizer = prawcore.DeviceIDAuthorizer(
             prawcore.TrustedAuthenticator(
                 requestor,
-                pytest.placeholders.client_id,
-                pytest.placeholders.client_secret,
+                placeholders.client_id,
+                placeholders.client_secret,
             ),
             scopes=scope_list,
         )
@@ -190,8 +191,8 @@ class TestScriptAuthorizer(IntegrationTest):
     def test_refresh(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             trusted_authenticator,
-            pytest.placeholders.username,
-            pytest.placeholders.password,
+            placeholders.username,
+            placeholders.password,
         )
         assert authorizer.access_token is None
         assert authorizer.scopes is None
@@ -205,8 +206,8 @@ class TestScriptAuthorizer(IntegrationTest):
     def test_refresh__with_invalid_otp(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             trusted_authenticator,
-            pytest.placeholders.username,
-            pytest.placeholders.password,
+            placeholders.username,
+            placeholders.password,
             lambda: "fake",
         )
         with pytest.raises(prawcore.OAuthException):
@@ -214,7 +215,7 @@ class TestScriptAuthorizer(IntegrationTest):
         assert not authorizer.is_valid()
 
     def test_refresh__with_invalid_username_or_password(self, trusted_authenticator):
-        authorizer = prawcore.ScriptAuthorizer(trusted_authenticator, pytest.placeholders.username, "invalidpassword")
+        authorizer = prawcore.ScriptAuthorizer(trusted_authenticator, placeholders.username, "invalidpassword")
         with pytest.raises(prawcore.OAuthException):
             authorizer.refresh()
         assert not authorizer.is_valid()
@@ -223,8 +224,8 @@ class TestScriptAuthorizer(IntegrationTest):
         scope_list = {"adsedit", "adsread", "creddits", "history"}
         authorizer = prawcore.ScriptAuthorizer(
             trusted_authenticator,
-            pytest.placeholders.username,
-            pytest.placeholders.password,
+            placeholders.username,
+            placeholders.password,
             scopes=scope_list,
         )
         authorizer.refresh()
@@ -236,8 +237,8 @@ class TestScriptAuthorizer(IntegrationTest):
     def test_refresh__with_valid_otp(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             trusted_authenticator,
-            pytest.placeholders.username,
-            pytest.placeholders.password,
+            placeholders.username,
+            placeholders.password,
             lambda: "000000",
         )
         assert authorizer.access_token is None

--- a/tests/integration/test_sessions.py
+++ b/tests/integration/test_sessions.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import prawcore
+from tests.conftest import placeholders
 
 from . import IntegrationTest
 
@@ -22,8 +23,8 @@ class TestSession(IntegrationTest):
     def script_authorizer(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             trusted_authenticator,
-            pytest.placeholders.username,
-            pytest.placeholders.password,
+            placeholders.username,
+            placeholders.password,
         )
         authorizer.refresh()
         return authorizer
@@ -126,7 +127,7 @@ class TestSession(IntegrationTest):
     def test_request__okay_with_0_byte_content(self, script_authorizer):
         session = prawcore.Session(script_authorizer)
         data = {"model": dumps({"name": "redditdev"})}
-        path = f"/api/multi/user/{pytest.placeholders.username}/m/praw_x5g968f66a/r/redditdev"
+        path = f"/api/multi/user/{placeholders.username}/m/praw_x5g968f66a/r/redditdev"
         response = session.request("DELETE", path, data=data)
         assert response == ""
 
@@ -206,8 +207,8 @@ class TestSession(IntegrationTest):
         authorizer = prawcore.ReadOnlyAuthorizer(
             prawcore.TrustedAuthenticator(
                 requestor,
-                pytest.placeholders.client_id,
-                pytest.placeholders.client_secret,
+                placeholders.client_id,
+                placeholders.client_secret,
             )
         )
         with pytest.raises(prawcore.exceptions.ResponseException) as exception_info:
@@ -266,7 +267,7 @@ class TestSession(IntegrationTest):
         assert exception_info.value.response.status_code == 414
 
     def test_request__with_insufficient_scope(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=pytest.placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
         session = prawcore.Session(authorizer)
         with pytest.raises(prawcore.InsufficientScope):

--- a/tests/unit/test_authenticator.py
+++ b/tests/unit/test_authenticator.py
@@ -3,6 +3,7 @@
 import pytest
 
 import prawcore
+from tests.conftest import placeholders
 
 from . import UnitTest
 
@@ -10,12 +11,12 @@ from . import UnitTest
 class TestTrustedAuthenticator(UnitTest):
     @pytest.fixture
     def trusted_authenticator(self, trusted_authenticator):
-        trusted_authenticator.redirect_uri = pytest.placeholders.redirect_uri
+        trusted_authenticator.redirect_uri = placeholders.redirect_uri
         return trusted_authenticator
 
     def test_authorize_url(self, trusted_authenticator):
         url = trusted_authenticator.authorize_url("permanent", ["identity", "read"], "a_state")
-        assert f"client_id={pytest.placeholders.client_id}" in url
+        assert f"client_id={placeholders.client_id}" in url
         assert "duration=permanent" in url
         assert "response_type=code" in url
         assert "scope=identity+read" in url
@@ -38,12 +39,12 @@ class TestTrustedAuthenticator(UnitTest):
 class TestUntrustedAuthenticator(UnitTest):
     @pytest.fixture
     def untrusted_authenticator(self, untrusted_authenticator):
-        untrusted_authenticator.redirect_uri = pytest.placeholders.redirect_uri
+        untrusted_authenticator.redirect_uri = placeholders.redirect_uri
         return untrusted_authenticator
 
     def test_authorize_url__code(self, untrusted_authenticator):
         url = untrusted_authenticator.authorize_url("permanent", ["identity", "read"], "a_state")
-        assert f"client_id={pytest.placeholders.client_id}" in url
+        assert f"client_id={placeholders.client_id}" in url
         assert "duration=permanent" in url
         assert "response_type=code" in url
         assert "scope=identity+read" in url
@@ -69,7 +70,7 @@ class TestUntrustedAuthenticator(UnitTest):
 
     def test_authorize_url__token(self, untrusted_authenticator):
         url = untrusted_authenticator.authorize_url("temporary", ["identity", "read"], "a_state", implicit=True)
-        assert f"client_id={pytest.placeholders.client_id}" in url
+        assert f"client_id={placeholders.client_id}" in url
         assert "duration=temporary" in url
         assert "response_type=token" in url
         assert "scope=identity+read" in url

--- a/tests/unit/test_authorizer.py
+++ b/tests/unit/test_authorizer.py
@@ -3,6 +3,7 @@
 import pytest
 
 import prawcore
+from tests.conftest import placeholders
 
 from . import UnitTest
 
@@ -26,10 +27,10 @@ class TestAuthorizer(UnitTest):
         assert not authorizer.is_valid()
 
     def test_initialize__with_refresh_token(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=pytest.placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
         assert authorizer.access_token is None
         assert authorizer.scopes is None
-        assert pytest.placeholders.refresh_token == authorizer.refresh_token
+        assert placeholders.refresh_token == authorizer.refresh_token
         assert not authorizer.is_valid()
 
     def test_initialize__with_untrusted_authenticator(self):
@@ -47,7 +48,7 @@ class TestAuthorizer(UnitTest):
         assert not authorizer.is_valid()
 
     def test_revoke__without_access_token(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=pytest.placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
         with pytest.raises(prawcore.InvalidInvocation):
             authorizer.revoke(only_access=True)
 

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -9,6 +9,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, ReadTimeo
 import prawcore
 from prawcore.exceptions import RequestException
 from prawcore.sessions import FiniteRetryStrategy
+from tests.conftest import placeholders
 
 from . import UnitTest
 
@@ -18,8 +19,8 @@ class InvalidAuthorizer(prawcore.Authorizer):
         super().__init__(
             prawcore.TrustedAuthenticator(
                 requestor,
-                pytest.placeholders.client_id,
-                pytest.placeholders.client_secret,
+                placeholders.client_id,
+                placeholders.client_secret,
             )
         )
 
@@ -66,8 +67,8 @@ class TestSession(UnitTest):
         requestor = prawcore.Requestor("prawcore:test (by /u/bboe)")
         authenticator = prawcore.TrustedAuthenticator(
             requestor,
-            pytest.placeholders.client_id,
-            pytest.placeholders.client_secret,
+            placeholders.client_id,
+            placeholders.client_secret,
         )
         authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
         authorizer.refresh()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from vcr.persisters.filesystem import FilesystemPersister
 from vcr.serialize import deserialize, serialize
 
-from tests.conftest import placeholders as _placeholders
+from tests.conftest import placeholder_values as _placeholders
 
 
 def ensure_integration_test(cassette):
@@ -73,13 +73,13 @@ class CustomPersister(FilesystemPersister):
             cassette_content = cassette_content.replace(value, replacement)
         return deserialize(cassette_content, serializer)
 
-    @classmethod
-    def save_cassette(cls, cassette_path, cassette_dict, serializer):  # pragma: no cover
+    @staticmethod
+    def save_cassette(cassette_path, cassette_dict, serializer):  # pragma: no cover
         """Save cassette."""
         cassette_path = Path(cassette_path)
         data = serialize(cassette_dict, serializer)
         for replacement, value in [
-            (f"<{k.upper()}>", v) for k, v in {**cls.additional_placeholders, **_placeholders}.items()
+            (f"<{k.upper()}>", v) for k, v in {**CustomPersister.additional_placeholders, **_placeholders}.items()
         ]:
             data = data.replace(value, replacement)
         dirname = cassette_path.parent


### PR DESCRIPTION
## Summary

Improves prawcore's typing story in three steps:

1. **Fix pyright errors in the test suite** — replaces the dynamically-attached
   ``pytest.placeholders`` attribute with a typed ``Placeholders`` singleton imported
   from ``conftest``, and converts ``CustomPersister.save_cassette`` to a staticmethod
   matching its ``FilesystemPersister`` base. Clears 56 pyright errors in ``tests/``
   with no runtime behavior change.
2. **Enable pyright strict mode** — adds a ``[tool.pyright]`` strict config (run via the
   tox ``type`` env) and resolves everything it surfaces: explicit ``__all__`` exports,
   a typed ``AUTHENTICATOR_CLASS`` and ``two_factor_callback``, an ``object``-typed
   ``__exit__``, and an ``isinstance`` runtime guard for ``Requestor``'s ``user_agent``.
   ``reportPrivateUsage`` is disabled because prawcore's authorizer, authenticator, and
   session classes intentionally share protected members within the package.
3. **Ship a ``py.typed`` marker** (:pep:`561`) plus the ``Typing :: Typed`` classifier so
   downstream projects type check against prawcore's inline annotations. flit bundles the
   marker into the wheel automatically.

## Test plan

- ``tox -e type`` (strict): 0 errors
- ``pytest``: 109 passed
- ``ruff check .``: clean
- Verified ``prawcore/py.typed`` ships in the built wheel