### PR TITLE
Widen session() authorizer parameter to BaseAuthorizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ prawcore follows `semantic versioning <https://semver.org/>`_.
 - Add a ``py.typed`` marker (:PEP:`561`) so that downstream projects can type check
   against prawcore's inline annotations.
 
+**Changed**
+
+- Widen the ``authorizer`` parameter of :func:`.session` to ``BaseAuthorizer`` to match
+  :class:`.Session`, so that passing an :class:`.ImplicitAuthorizer` or
+  :class:`.DeviceIDAuthorizer` type checks.
+
 ********************
  3.1.0 (2026/06/07)
 ********************

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from requests.models import Response
     from typing_extensions import Self
 
-    from .auth import Authorizer
     from .requestor import Requestor
 
 log = logging.getLogger(__package__)
@@ -378,12 +377,12 @@ class Session:
 
 
 def session(
-    authorizer: Authorizer | None = None,
+    authorizer: BaseAuthorizer | None = None,
     window_size: int = WINDOW_SIZE,
 ) -> Session:
     """Return a :class:`.Session` instance.
 
-    :param authorizer: An instance of :class:`.Authorizer`.
+    :param authorizer: An instance of :class:`.BaseAuthorizer`.
     :param window_size: The size of the rate limit reset window in seconds.
 
     """


### PR DESCRIPTION
## Summary

`prawcore.session()` annotated its `authorizer` parameter as `Authorizer`, but it delegates directly to `Session`, whose `__init__` already accepts any `BaseAuthorizer` (and guards with `isinstance(authorizer, BaseAuthorizer)` at runtime).

The factory was therefore *stricter than the class it wraps*: `ImplicitAuthorizer` and `DeviceIDAuthorizer` derive from `BaseAuthorizer` rather than `Authorizer`, so passing them to `session()` was rejected by type checkers even though it works at runtime. This forced downstream callers — e.g. PRAW's read-only session — to add `# pyright: ignore[reportArgumentType]`.

This widens the parameter to `BaseAuthorizer` to match `Session`. No runtime behavior change.

## Verification

- `pyright` (strict): 0 errors
- Full test suite: 109 passed
- pre-commit: all hooks pass