### PR TITLE
Widen Session.request parameter annotations to match runtime

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ prawcore follows `semantic versioning <https://semver.org/>`_.
 - Widen the ``authorizer`` parameter of :func:`.session` to ``BaseAuthorizer`` to match
   :class:`.Session`, so that passing an :class:`.ImplicitAuthorizer` or
   :class:`.DeviceIDAuthorizer` type checks.
+- Widen the ``data``, ``files``, ``json``, and ``params`` parameter annotations of
+  :meth:`.Session.request` to reflect the values it already accepts at runtime (for
+  example a non-dict ``data`` body, a ``list`` ``json`` payload, and any ``IO`` file
+  object), so that callers no longer need to cast these arguments.
 
 ********************
  3.1.0 (2026/06/07)

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
 from pprint import pformat
-from typing import TYPE_CHECKING, BinaryIO, TextIO
+from typing import IO, TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 from requests.exceptions import ChunkedEncodingError, ConnectionError, ReadTimeout
@@ -37,6 +37,8 @@ from .rate_limit import RateLimiter
 from .util import authorization_error_class
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from requests.models import Response
     from typing_extensions import Self
 
@@ -138,7 +140,7 @@ class Session:
     @staticmethod
     def _log_request(
         *,
-        data: list[tuple[str, object]] | None,
+        data: list[tuple[str, object]] | bytes | IO[Any] | str | None,
         method: str,
         params: dict[str, object],
         url: str,
@@ -180,9 +182,9 @@ class Session:
     def _do_retry(
         self,
         *,
-        data: list[tuple[str, object]] | None,
-        files: dict[str, BinaryIO | TextIO] | None,
-        json: dict[str, object] | None,
+        data: list[tuple[str, object]] | bytes | IO[Any] | str | None,
+        files: dict[str, IO[Any]] | None,
+        json: dict[str, object] | list[object] | None,
         method: str,
         params: dict[str, object],
         retry_strategy_state: FiniteRetryStrategy,
@@ -205,9 +207,9 @@ class Session:
 
     def _make_request(
         self,
-        data: list[tuple[str, object]] | None,
-        files: dict[str, BinaryIO | TextIO] | None,
-        json: dict[str, object] | None,
+        data: list[tuple[str, object]] | bytes | IO[Any] | str | None,
+        files: dict[str, IO[Any]] | None,
+        json: dict[str, object] | list[object] | None,
         method: str,
         params: dict[str, object],
         timeout: float,
@@ -239,9 +241,9 @@ class Session:
     def _request_with_retries(
         self,
         *,
-        data: list[tuple[str, object]] | None,
-        files: dict[str, BinaryIO | TextIO] | None,
-        json: dict[str, object] | None,
+        data: list[tuple[str, object]] | bytes | IO[Any] | str | None,
+        files: dict[str, IO[Any]] | None,
+        json: dict[str, object] | list[object] | None,
         method: str,
         params: dict[str, object],
         retry_strategy_state: FiniteRetryStrategy | None = None,
@@ -328,10 +330,10 @@ class Session:
         self,
         method: str,
         path: str,
-        data: dict[str, object] | None = None,
-        files: dict[str, BinaryIO | TextIO] | None = None,
-        json: dict[str, object] | None = None,
-        params: dict[str, object] | None = None,
+        data: dict[str, object] | bytes | IO[Any] | str | None = None,
+        files: dict[str, IO[Any]] | None = None,
+        json: dict[str, object] | list[object] | None = None,
+        params: Mapping[str, object] | None = None,
         timeout: float = TIMEOUT,
     ) -> dict[str, object] | str | None:
         """Return the json content from the resource at ``path``.
@@ -353,7 +355,7 @@ class Session:
             available.
 
         """
-        params = deepcopy(params) or {}
+        params = deepcopy(dict(params)) if params else {}
         params["raw_json"] = 1
         if isinstance(data, dict):
             data = deepcopy(data)


### PR DESCRIPTION
## Summary

`Session.request` annotated `data`, `files`, `json`, and `params` more narrowly than the values it actually accepts at runtime (and than its own docstring documents). This forced downstream callers — notably PRAW — to `cast()` every argument at the call site.

| Param | Was | Now | Why |
|-------|-----|-----|-----|
| `data` | `dict[str, object] \| None` | `dict[str, object] \| bytes \| IO[Any] \| str \| None` | The non-dict branch (`data_list = data`) passes bytes/str/file-like straight through to `requests`; the docstring already says "Dictionary, bytes, or file-like object." |
| `json` | `dict[str, object] \| None` | `dict[str, object] \| list[object] \| None` | The `isinstance(json, dict)` guard lets a `list` payload pass through untouched. |
| `files` | `dict[str, BinaryIO \| TextIO]` | `dict[str, IO[Any]]` | `IO` is the supertype; the old type was needlessly narrow. |
| `params` | `dict[str, object] \| None` | `Mapping[str, object] \| None` | `dict` is invariant, so a narrower-valued dict (e.g. `dict[str, str \| int]`) was rejected. `params` is copied before mutation, so a covariant `Mapping` is safe. |

The internal retry chain (`_log_request`, `_do_retry`, `_make_request`, `_request_with_retries`) is widened consistently. `params` is now copied via `dict(params)` before the `raw_json` key is added.

No runtime behavior change — this only lets callers drop the casts they currently need around `request()`.

## Verification

- `pyright` (strict): 0 errors
- Full test suite: 109 passed
- pre-commit: all hooks pass