### PR TITLE
Expose public accessors and re-enable reportPrivateUsage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ prawcore follows `semantic versioning <https://semver.org/>`_.
 - Add an ``__all__`` to the ``prawcore`` package to explicitly define its public API.
 - Add a ``py.typed`` marker (:PEP:`561`) so that downstream projects can type check
   against prawcore's inline annotations.
+- Add read-only :attr:`.Session.authorizer`, :attr:`.Session.rate_limiter`, and
+  :attr:`.Session.requestor` properties, a :attr:`.BaseAuthorizer.authenticator`
+  property, and a :attr:`.BaseAuthenticator.requestor` property, so that downstream code
+  can reach these objects without accessing protected attributes.
 
 **Changed**
 

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -27,6 +27,11 @@ class BaseAuthenticator(ABC):
     def _auth(self) -> tuple[str, str]:
         pass
 
+    @property
+    def requestor(self) -> Requestor:
+        """Return the :class:`.Requestor` used to issue HTTP requests."""
+        return self._requestor
+
     def __init__(
         self,
         requestor: Requestor,
@@ -127,6 +132,11 @@ class BaseAuthorizer:
 
     AUTHENTICATOR_CLASS: type[BaseAuthenticator] | tuple[type[BaseAuthenticator], ...] = BaseAuthenticator
 
+    @property
+    def authenticator(self) -> BaseAuthenticator:
+        """Return the :class:`.BaseAuthenticator` used to authenticate requests."""
+        return self._authenticator
+
     def __init__(self, authenticator: BaseAuthenticator) -> None:
         """Represent a single authorization to Reddit's API.
 
@@ -143,9 +153,10 @@ class BaseAuthorizer:
         self.scopes: set[str] | None = None
 
     def _request_token(self, **data: Any):
-        url = self._authenticator._requestor.reddit_url + const.ACCESS_TOKEN_PATH
+        url = self._authenticator.requestor.reddit_url + const.ACCESS_TOKEN_PATH
         pre_request_timestamp_ns = time.monotonic_ns()
-        response = self._authenticator._post(url=url, **data)
+        # _post is an internal helper shared between the authenticator and authorizer.
+        response = self._authenticator._post(url=url, **data)  # pyright: ignore[reportPrivateUsage]
         payload = response.json()
         if "error" in payload:  # Why are these OKAY responses?
             raise OAuthException(response, payload["error"], payload.get("error_description"))

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -137,6 +137,11 @@ class Session:
     }
     SUCCESS_STATUSES = {codes["accepted"], codes["created"], codes["ok"]}
 
+    @property
+    def authorizer(self) -> BaseAuthorizer:
+        """Return the :class:`.BaseAuthorizer` used to authorize requests."""
+        return self._authorizer
+
     @staticmethod
     def _log_request(
         *,
@@ -150,8 +155,14 @@ class Session:
         log.debug("Params: %s", pformat(params))
 
     @property
-    def _requestor(self) -> Requestor:
-        return self._authorizer._authenticator._requestor
+    def rate_limiter(self) -> RateLimiter:
+        """Return the :class:`.RateLimiter` that throttles requests."""
+        return self._rate_limiter
+
+    @property
+    def requestor(self) -> Requestor:
+        """Return the :class:`.Requestor` used to issue HTTP requests."""
+        return self._authorizer.authenticator.requestor
 
     def __enter__(self) -> Self:
         """Allow this object to be used as a context manager."""
@@ -216,7 +227,7 @@ class Session:
         url: str,
     ) -> Response:
         response = self._rate_limiter.call(
-            self._requestor.request,
+            self.requestor.request,
             self._set_header_callback,
             method,
             url,
@@ -285,7 +296,8 @@ class Session:
 
         retry_status = None
         if response.status_code == codes["unauthorized"]:
-            self._authorizer._clear_access_token()
+            # _clear_access_token is an internal helper shared with the authorizer.
+            self._authorizer._clear_access_token()  # pyright: ignore[reportPrivateUsage]
             if hasattr(self._authorizer, "refresh"):
                 retry_status = f"{response.status_code} status"
         elif response.status_code in self.RETRY_STATUSES:
@@ -324,7 +336,7 @@ class Session:
 
     def close(self) -> None:
         """Close the session and perform any clean up."""
-        self._requestor.close()
+        self.requestor.close()
 
     def request(
         self,
@@ -366,7 +378,7 @@ class Session:
         if isinstance(json, dict):
             json = deepcopy(json)
             json["api_type"] = "json"
-        url = urljoin(self._requestor.oauth_url, path)
+        url = urljoin(self.requestor.oauth_url, path)
         return self._request_with_retries(
             data=data_list,
             files=files,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,6 @@ requires-python = ">=3.10"
 [tool.pyright]
 include = ["prawcore"]
 pythonVersion = "3.10"
-# prawcore's authorizer, authenticator, and session classes intentionally share
-# protected members within the package.
-reportPrivateUsage = false
 typeCheckingMode = "strict"
 
 [tool.ruff]

--- a/tests/integration/test_sessions.py
+++ b/tests/integration/test_sessions.py
@@ -193,7 +193,7 @@ class TestSession(IntegrationTest):
 
     def test_request__too__many_requests__with_retry_headers(self, readonly_authorizer):
         session = prawcore.Session(readonly_authorizer)
-        session._requestor._http.headers.update({"User-Agent": "python-requests/2.25.1"})
+        session.requestor._http.headers.update({"User-Agent": "python-requests/2.25.1"})
         with pytest.raises(prawcore.TooManyRequests) as exception_info:
             session.request("GET", "/api/v1/me")
         assert exception_info.value.response.status_code == 429

--- a/tests/unit/test_authorizer.py
+++ b/tests/unit/test_authorizer.py
@@ -13,6 +13,10 @@ class InvalidAuthenticator(prawcore.auth.BaseAuthenticator):
 
 
 class TestAuthorizer(UnitTest):
+    def test_authenticator(self, trusted_authenticator):
+        authorizer = prawcore.Authorizer(trusted_authenticator)
+        assert authorizer.authenticator is trusted_authenticator
+
     def test_authorize__fail_without_redirect_uri(self, trusted_authenticator):
         authorizer = prawcore.Authorizer(trusted_authenticator)
         with pytest.raises(prawcore.InvalidInvocation):

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -8,6 +8,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, ReadTimeo
 
 import prawcore
 from prawcore.exceptions import RequestException
+from prawcore.rate_limit import RateLimiter
 from prawcore.sessions import FiniteRetryStrategy
 from tests.conftest import placeholders
 
@@ -32,6 +33,13 @@ class TestSession(UnitTest):
     @pytest.fixture
     def readonly_authorizer(self, trusted_authenticator):
         return prawcore.ReadOnlyAuthorizer(trusted_authenticator)
+
+    def test_accessors(self, requestor, trusted_authenticator):
+        authorizer = prawcore.ReadOnlyAuthorizer(trusted_authenticator)
+        session = prawcore.Session(authorizer)
+        assert session.authorizer is authorizer
+        assert isinstance(session.rate_limiter, RateLimiter)
+        assert session.requestor is requestor
 
     def test_close(self, readonly_authorizer):
         prawcore.Session(readonly_authorizer).close()


### PR DESCRIPTION
## Summary

Downstream code — notably PRAW — needs the authorizer, rate limiter, and requestor behind a `Session`, and the authenticator/requestor behind an `Authorizer`/`Authenticator`. The only way to reach them was through protected attributes (`_authorizer`, `_rate_limiter`, `_requestor`, `_authenticator`), which trips type checkers that flag private-member access across package boundaries (`reportPrivateUsage`).

### Added (read-only properties)

- `Session.authorizer` → `BaseAuthorizer`
- `Session.rate_limiter` → `RateLimiter`
- `Session.requestor` → `Requestor`
- `BaseAuthorizer.authenticator` → `BaseAuthenticator`
- `BaseAuthenticator.requestor` → `Requestor`

The backing attributes are retained, so this is **purely additive** for external callers.

### Internal cleanup

- prawcore now uses the new accessors internally instead of reaching across another class's protected members.
- **`reportPrivateUsage` is re-enabled** (it was previously disabled wholesale). Two genuinely-internal private method calls between the tightly-coupled auth/session classes — `_post` and `_clear_access_token` — keep a scoped `# pyright: ignore[reportPrivateUsage]`.
- `Session.requestor` computes the requestor chain directly, so the now-redundant private `Session._requestor` property is **removed** (private member; not part of the public API).

## Verification

- `pyright` (strict, with `reportPrivateUsage` active): 0 errors
- Full test suite: 111 passed
- Coverage: 100% (`--fail-under=100`)
- pre-commit: all hooks pass

## Note for PRAW

PRAW's `media.py` currently reads `reddit._core._requestor`; once this releases it should switch to `reddit._core.requestor`. This is part of the planned PRAW-side cast/ignore cleanup.