### PR TITLE
Add Documentation section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,12 @@ Save the above as ``trophies.py`` and then execute via:
 Additional examples can be found at:
 https://github.com/praw-dev/prawcore/tree/main/examples
 
+***************
+ Documentation
+***************
+
+prawcore's documentation is located at https://prawcore.readthedocs.io/.
+
 ***********************
  Depending on prawcore
 ***********************


### PR DESCRIPTION
Adds a ``Documentation`` section to the README pointing to the new Read the Docs site (https://prawcore.readthedocs.io/), mirroring how praw's README references its docs.