### PR TITLE
Make public parameters keyword-only or positional-only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,14 +10,15 @@ prawcore follows `semantic versioning <https://semver.org/>`_.
 
 **Changed**
 
-- Make the parameters of :meth:`.BaseAuthenticator.authorize_url` keyword-only, so that
-  callers must pass ``duration``, ``scopes``, and ``state`` (and any other arguments) by
-  name.
-- Make the ``only_access`` argument of :meth:`.Authorizer.revoke` keyword-only.
-- Make the parameters of :class:`.Requestor` keyword-only, so that callers must pass
-  ``user_agent`` (and any other arguments) by name.
-- Make the parameters of :meth:`.Session.request` keyword-only, so that callers must
-  pass ``method`` and ``path`` (and any other arguments) by name.
+- Make every public parameter either keyword-only or positional-only. The ``requestor``,
+  ``authenticator``, and ``authorizer`` subjects of the authenticator and authorizer
+  classes, the parameters of :class:`.Requestor`, :meth:`.Session.request`, and
+  :meth:`.BaseAuthenticator.authorize_url`, the ``only_access`` argument of
+  :meth:`.Authorizer.revoke`, and the ``session`` factory are now keyword-only, while
+  the single obvious operand of a method (such as the ``token`` argument of
+  :meth:`.BaseAuthenticator.revoke_token`, the ``code`` argument of
+  :meth:`.Authorizer.authorize`, and the ``response`` argument of the exception classes)
+  is positional-only.
 
 ********************
  3.2.1 (2026/06/10)

--- a/README.rst
+++ b/README.rst
@@ -67,15 +67,15 @@ appropriate values for your application.
     import prawcore
 
     authenticator = prawcore.TrustedAuthenticator(
-        prawcore.Requestor(user_agent="YOUR_VALID_USER_AGENT"),
-        os.environ["PRAWCORE_CLIENT_ID"],
-        os.environ["PRAWCORE_CLIENT_SECRET"],
+        client_id=os.environ["PRAWCORE_CLIENT_ID"],
+        client_secret=os.environ["PRAWCORE_CLIENT_SECRET"],
+        requestor=prawcore.Requestor(user_agent="YOUR_VALID_USER_AGENT"),
     )
-    authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
+    authorizer = prawcore.ReadOnlyAuthorizer(authenticator=authenticator)
     authorizer.refresh()
 
-    with prawcore.session(authorizer) as session:
-        pprint.pprint(session.request("GET", "/api/v1/user/bboe/trophies"))
+    with prawcore.session(authorizer=authorizer) as session:
+        pprint.pprint(session.request(method="GET", path="/api/v1/user/bboe/trophies"))
 
 Save the above as ``trophies.py`` and then execute via:
 

--- a/examples/caching_requestor.py
+++ b/examples/caching_requestor.py
@@ -47,18 +47,18 @@ def main():
 
     caching_requestor = prawcore.Requestor(user_agent="prawcore_device_id_auth_example", session=CachingSession())
     authenticator = prawcore.TrustedAuthenticator(
-        caching_requestor,
-        os.environ["PRAWCORE_CLIENT_ID"],
-        os.environ["PRAWCORE_CLIENT_SECRET"],
+        client_id=os.environ["PRAWCORE_CLIENT_ID"],
+        client_secret=os.environ["PRAWCORE_CLIENT_SECRET"],
+        requestor=caching_requestor,
     )
-    authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
+    authorizer = prawcore.ReadOnlyAuthorizer(authenticator=authenticator)
     authorizer.refresh()
 
     user = sys.argv[1]
-    with prawcore.session(authorizer) as session:
+    with prawcore.session(authorizer=authorizer) as session:
         data1 = session.request(method="GET", path=f"/api/v1/user/{user}/trophies")
 
-    with prawcore.session(authorizer) as session:
+    with prawcore.session(authorizer=authorizer) as session:
         data2 = session.request(method="GET", path=f"/api/v1/user/{user}/trophies")
 
     for trophy in data1["data"]["trophies"]:

--- a/examples/device_id_auth_trophies.py
+++ b/examples/device_id_auth_trophies.py
@@ -19,14 +19,14 @@ def main():
         return 1
 
     authenticator = prawcore.UntrustedAuthenticator(
-        prawcore.Requestor(user_agent="prawcore_device_id_auth_example"),
-        os.environ["PRAWCORE_CLIENT_ID"],
+        client_id=os.environ["PRAWCORE_CLIENT_ID"],
+        requestor=prawcore.Requestor(user_agent="prawcore_device_id_auth_example"),
     )
-    authorizer = prawcore.DeviceIDAuthorizer(authenticator)
+    authorizer = prawcore.DeviceIDAuthorizer(authenticator=authenticator)
     authorizer.refresh()
 
     user = sys.argv[1]
-    with prawcore.session(authorizer) as session:
+    with prawcore.session(authorizer=authorizer) as session:
         data = session.request(method="GET", path=f"/api/v1/user/{user}/trophies")
 
     for trophy in data["data"]["trophies"]:

--- a/examples/obtain_refresh_token.py
+++ b/examples/obtain_refresh_token.py
@@ -47,10 +47,10 @@ def main():
         return 1
 
     authenticator = prawcore.TrustedAuthenticator(
-        prawcore.Requestor(user_agent="prawcore_refresh_token_example"),
-        os.environ["PRAWCORE_CLIENT_ID"],
-        os.environ["PRAWCORE_CLIENT_SECRET"],
-        "http://localhost:8080",
+        client_id=os.environ["PRAWCORE_CLIENT_ID"],
+        client_secret=os.environ["PRAWCORE_CLIENT_SECRET"],
+        redirect_uri="http://localhost:8080",
+        requestor=prawcore.Requestor(user_agent="prawcore_refresh_token_example"),
     )
 
     state = str(random.randint(0, 65000))
@@ -72,7 +72,7 @@ def main():
         send_message(client, params["error"])
         return 1
 
-    authorizer = prawcore.Authorizer(authenticator)
+    authorizer = prawcore.Authorizer(authenticator=authenticator)
     authorizer.authorize(params["code"])
 
     send_message(client, f"Refresh token: {authorizer.refresh_token}")

--- a/examples/read_only_auth_trophies.py
+++ b/examples/read_only_auth_trophies.py
@@ -20,15 +20,15 @@ def main():
         return 1
 
     authenticator = prawcore.TrustedAuthenticator(
-        prawcore.Requestor(user_agent="prawcore_read_only_example"),
-        os.environ["PRAWCORE_CLIENT_ID"],
-        os.environ["PRAWCORE_CLIENT_SECRET"],
+        client_id=os.environ["PRAWCORE_CLIENT_ID"],
+        client_secret=os.environ["PRAWCORE_CLIENT_SECRET"],
+        requestor=prawcore.Requestor(user_agent="prawcore_read_only_example"),
     )
-    authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
+    authorizer = prawcore.ReadOnlyAuthorizer(authenticator=authenticator)
     authorizer.refresh()
 
     user = sys.argv[1]
-    with prawcore.session(authorizer) as session:
+    with prawcore.session(authorizer=authorizer) as session:
         data = session.request(method="GET", path=f"/api/v1/user/{user}/trophies")
 
     for trophy in data["data"]["trophies"]:

--- a/examples/script_auth_friend_list.py
+++ b/examples/script_auth_friend_list.py
@@ -17,18 +17,18 @@ import prawcore
 def main():
     """Provide the program's entry point when directly executed."""
     authenticator = prawcore.TrustedAuthenticator(
-        prawcore.Requestor(user_agent="prawcore_script_auth_example"),
-        os.environ["PRAWCORE_CLIENT_ID"],
-        os.environ["PRAWCORE_CLIENT_SECRET"],
+        client_id=os.environ["PRAWCORE_CLIENT_ID"],
+        client_secret=os.environ["PRAWCORE_CLIENT_SECRET"],
+        requestor=prawcore.Requestor(user_agent="prawcore_script_auth_example"),
     )
     authorizer = prawcore.ScriptAuthorizer(
-        authenticator,
-        os.environ["PRAWCORE_USERNAME"],
-        os.environ["PRAWCORE_PASSWORD"],
+        authenticator=authenticator,
+        username=os.environ["PRAWCORE_USERNAME"],
+        password=os.environ["PRAWCORE_PASSWORD"],
     )
     authorizer.refresh()
 
-    with prawcore.session(authorizer) as session:
+    with prawcore.session(authorizer=authorizer) as session:
         data = session.request(method="GET", path="/api/v1/me/friends")
 
     for friend in data["data"]["children"]:

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -34,19 +34,20 @@ class BaseAuthenticator(ABC):
 
     def __init__(
         self,
-        requestor: Requestor,
+        *,
         client_id: str,
         redirect_uri: str | None = None,
+        requestor: Requestor,
     ) -> None:
         """Represent a single authentication to Reddit's API.
 
-        :param requestor: An instance of :class:`.Requestor`.
         :param client_id: The OAuth2 client ID to use with the session.
         :param redirect_uri: The redirect URI exactly as specified in your OAuth
             application settings on Reddit. This parameter is required if you want to
             use the :meth:`~.Authorizer.authorize_url` method, or the
             :meth:`~.Authorizer.authorize` method of the :class:`.Authorizer` class
             (default: ``None``).
+        :param requestor: An instance of :class:`.Requestor`.
 
         """
         self._requestor = requestor
@@ -111,7 +112,7 @@ class BaseAuthenticator(ABC):
         request = Request("GET", url, params=params)
         return cast("str", request.prepare().url)
 
-    def revoke_token(self, token: str, token_type: str | None = None) -> None:
+    def revoke_token(self, token: str, /, *, token_type: str | None = None) -> None:
         """Ask Reddit to revoke the provided token.
 
         :param token: The access or refresh token to revoke.
@@ -137,7 +138,7 @@ class BaseAuthorizer:
         """Return the :class:`.BaseAuthenticator` used to authenticate requests."""
         return self._authenticator
 
-    def __init__(self, authenticator: BaseAuthenticator) -> None:
+    def __init__(self, *, authenticator: BaseAuthenticator) -> None:
         """Represent a single authorization to Reddit's API.
 
         :param authenticator: An instance of :class:`.BaseAuthenticator`.
@@ -191,7 +192,7 @@ class BaseAuthorizer:
             msg = "no token available to revoke"
             raise InvalidInvocation(msg)
 
-        self._authenticator.revoke_token(self.access_token, "access_token")
+        self._authenticator.revoke_token(self.access_token, token_type="access_token")  # noqa: S106
         self._clear_access_token()
 
 
@@ -202,14 +203,14 @@ class TrustedAuthenticator(BaseAuthenticator):
 
     def __init__(
         self,
-        requestor: Requestor,
+        *,
         client_id: str,
         client_secret: str,
         redirect_uri: str | None = None,
+        requestor: Requestor,
     ) -> None:
         """Represent a single authentication to Reddit's API.
 
-        :param requestor: An instance of :class:`.Requestor`.
         :param client_id: The OAuth2 client ID to use with the session.
         :param client_secret: The OAuth2 client secret to use with the session.
         :param redirect_uri: The redirect URI exactly as specified in your OAuth
@@ -217,9 +218,10 @@ class TrustedAuthenticator(BaseAuthenticator):
             use the :meth:`~.Authorizer.authorize_url` method, or the
             :meth:`~.Authorizer.authorize` method of the :class:`.Authorizer` class
             (default: ``None``).
+        :param requestor: An instance of :class:`.Requestor`.
 
         """
-        super().__init__(requestor, client_id, redirect_uri)
+        super().__init__(client_id=client_id, redirect_uri=redirect_uri, requestor=requestor)
         self.client_secret = client_secret
 
     def _auth(self) -> tuple[str, str]:
@@ -238,8 +240,8 @@ class Authorizer(BaseAuthorizer):
 
     def __init__(
         self,
-        authenticator: BaseAuthenticator,
         *,
+        authenticator: BaseAuthenticator,
         post_refresh_callback: Callable[[Authorizer], None] | None = None,
         pre_refresh_callback: Callable[[Authorizer], None] | None = None,
         refresh_token: str | None = None,
@@ -260,12 +262,12 @@ class Authorizer(BaseAuthorizer):
         :param refresh_token: Enables the ability to refresh the authorization.
 
         """
-        super().__init__(authenticator)
+        super().__init__(authenticator=authenticator)
         self._post_refresh_callback = post_refresh_callback
         self._pre_refresh_callback = pre_refresh_callback
         self.refresh_token = refresh_token
 
-    def authorize(self, code: str) -> None:
+    def authorize(self, code: str, /) -> None:
         """Obtain and set authorization tokens based on ``code``.
 
         :param code: The code obtained by an out-of-band authorization request to
@@ -305,7 +307,7 @@ class Authorizer(BaseAuthorizer):
         if only_access or self.refresh_token is None:
             super().revoke()
         else:
-            self._authenticator.revoke_token(self.refresh_token, "refresh_token")
+            self._authenticator.revoke_token(self.refresh_token, token_type="refresh_token")  # noqa: S106
             self._clear_access_token()
             self.refresh_token = None
 
@@ -317,16 +319,17 @@ class ImplicitAuthorizer(BaseAuthorizer):
 
     def __init__(
         self,
-        authenticator: UntrustedAuthenticator,
+        *,
         access_token: str,
+        authenticator: UntrustedAuthenticator,
         expires_in: int,
         scope: str,
     ) -> None:
         """Represent a single implicit authorization to Reddit's API.
 
-        :param authenticator: An instance of :class:`.UntrustedAuthenticator`.
         :param access_token: The ``access_token`` obtained from Reddit via callback to
             the authenticator's ``redirect_uri``.
+        :param authenticator: An instance of :class:`.UntrustedAuthenticator`.
         :param expires_in: The number of seconds the ``access_token`` is valid for. The
             origin of this value was returned from Reddit via callback to the
             authenticator's redirect uri. Note, you may need to subtract an offset
@@ -336,7 +339,7 @@ class ImplicitAuthorizer(BaseAuthorizer):
             from Reddit in the callback to the authenticator's redirect uri.
 
         """
-        super().__init__(authenticator)
+        super().__init__(authenticator=authenticator)
         self._expiration_timestamp_ns = time.monotonic_ns() + expires_in * const.NANOSECONDS
         self.access_token = access_token
         self.scopes = set(scope.split(" "))
@@ -354,6 +357,7 @@ class ReadOnlyAuthorizer(Authorizer):
 
     def __init__(
         self,
+        *,
         authenticator: BaseAuthenticator,
         scopes: list[str] | None = None,
     ) -> None:
@@ -363,7 +367,7 @@ class ReadOnlyAuthorizer(Authorizer):
             ``None``). The scope ``"*"`` is requested when the default argument is used.
 
         """
-        super().__init__(authenticator)
+        super().__init__(authenticator=authenticator)
         self._scopes = scopes
 
     def refresh(self) -> None:
@@ -386,25 +390,26 @@ class ScriptAuthorizer(Authorizer):
 
     def __init__(
         self,
+        *,
         authenticator: BaseAuthenticator,
-        username: str | None,
         password: str | None,
-        two_factor_callback: Callable[[], str] | None = None,
         scopes: list[str] | None = None,
+        two_factor_callback: Callable[[], str] | None = None,
+        username: str | None,
     ) -> None:
         """Represent a single personal-use authorization to Reddit's API.
 
         :param authenticator: An instance of :class:`.TrustedAuthenticator`.
-        :param username: The Reddit username of one of the application's developers.
         :param password: The password associated with ``username``.
+        :param scopes: A list of OAuth scopes to request authorization for (default:
+            ``None``). The scope ``"*"`` is requested when the default argument is used.
         :param two_factor_callback: A function that returns OTPs (One-Time Passcodes),
             also known as 2FA auth codes. If this function is provided, prawcore will
             call it when authenticating.
-        :param scopes: A list of OAuth scopes to request authorization for (default:
-            ``None``). The scope ``"*"`` is requested when the default argument is used.
+        :param username: The Reddit username of one of the application's developers.
 
         """
-        super().__init__(authenticator)
+        super().__init__(authenticator=authenticator)
         self._password = password
         self._scopes = scopes
         self._two_factor_callback = two_factor_callback
@@ -438,6 +443,7 @@ class DeviceIDAuthorizer(BaseAuthorizer):
 
     def __init__(
         self,
+        *,
         authenticator: BaseAuthenticator,
         device_id: str | None = None,
         scopes: list[str] | None = None,
@@ -456,7 +462,7 @@ class DeviceIDAuthorizer(BaseAuthorizer):
         """
         if device_id is None:
             device_id = "DO_NOT_TRACK_THIS_DEVICE"
-        super().__init__(authenticator)
+        super().__init__(authenticator=authenticator)
         self._device_id = device_id
         self._scopes = scopes
 

--- a/prawcore/exceptions.py
+++ b/prawcore/exceptions.py
@@ -42,7 +42,7 @@ class InvalidInvocation(PrawcoreException):
 class OAuthException(PrawcoreException):
     """Indicate that there was an OAuth2 related error with the request."""
 
-    def __init__(self, response: requests.Response, error: str, description: str | None = None) -> None:
+    def __init__(self, response: requests.Response, /, error: str, description: str | None = None) -> None:
         """Initialize a OAuthException instance.
 
         :param response: A :class:`requests.Response` instance.
@@ -84,7 +84,7 @@ class RequestException(PrawcoreException):
 class ResponseException(PrawcoreException):
     """Indicate that there was an error with the completed HTTP request."""
 
-    def __init__(self, response: requests.Response) -> None:
+    def __init__(self, response: requests.Response, /) -> None:
         """Initialize a ResponseException instance.
 
         :param response: A :class:`requests.Response` instance.
@@ -130,7 +130,7 @@ class Redirect(ResponseException):
 
     """
 
-    def __init__(self, response: requests.Response) -> None:
+    def __init__(self, response: requests.Response, /) -> None:
         """Initialize a Redirect exception instance.
 
         :param response: A :class:`requests.Response` instance containing a location
@@ -156,7 +156,7 @@ class ServerError(ResponseException):
 class SpecialError(ResponseException):
     """Indicate syntax or spam-prevention issues."""
 
-    def __init__(self, response: requests.Response) -> None:
+    def __init__(self, response: requests.Response, /) -> None:
         """Initialize a SpecialError exception instance.
 
         :param response: A :class:`requests.Response` instance containing a message and
@@ -179,7 +179,7 @@ class TooLarge(ResponseException):
 class TooManyRequests(ResponseException):
     """Indicate that the user has sent too many requests in a given amount of time."""
 
-    def __init__(self, response: requests.Response) -> None:
+    def __init__(self, response: requests.Response, /) -> None:
         """Initialize a TooManyRequests exception instance.
 
         :param response: A :class:`requests.Response` instance that may contain a

--- a/prawcore/rate_limit.py
+++ b/prawcore/rate_limit.py
@@ -32,24 +32,27 @@ class RateLimiter:
 
     def call(
         self,
-        request_function: Callable[[Any], Response],
+        *,
+        method: str,
+        request_function: Callable[..., Response],
         set_header_callback: Callable[[], dict[str, str]],
-        *args: Any,
+        url: str,
         **kwargs: Any,
     ) -> Response:
         """Rate limit the call to ``request_function``.
 
+        :param method: The HTTP method of the request.
         :param request_function: A function call that returns an HTTP response object.
         :param set_header_callback: A callback function used to set the request headers.
             This callback is called after any necessary sleep time occurs.
-        :param args: The positional arguments to ``request_function``.
+        :param url: The URL of the request.
         :param kwargs: The keyword arguments to ``request_function``.
 
         """
         self.delay()
         kwargs["headers"] = set_header_callback()
-        response = request_function(*args, **kwargs)
-        self.update(response.headers)
+        response = request_function(method, url, **kwargs)
+        self.update(response_headers=response.headers)
         return response
 
     def delay(self) -> None:
@@ -63,7 +66,7 @@ class RateLimiter:
         log.debug(message)
         time.sleep(sleep_seconds)
 
-    def update(self, response_headers: Mapping[str, str]) -> None:
+    def update(self, *, response_headers: Mapping[str, str]) -> None:
         """Update the state of the rate limiter based on the response headers.
 
         This method should only be called following an HTTP request to Reddit.

--- a/prawcore/sessions.py
+++ b/prawcore/sessions.py
@@ -177,6 +177,7 @@ class Session:
 
     def __init__(
         self,
+        *,
         authorizer: BaseAuthorizer | None,
         window_size: int = WINDOW_SIZE,
     ) -> None:
@@ -230,16 +231,16 @@ class Session:
         url: str,
     ) -> Response:
         response = self._rate_limiter.call(
-            self.requestor.request,
-            self._set_header_callback,
-            method,
-            url,
             allow_redirects=False,
             data=data,
             files=files,
             json=json,
+            method=method,
             params=params,
+            request_function=self.requestor.request,
+            set_header_callback=self._set_header_callback,
             timeout=timeout,
+            url=url,
         )
         log.debug(
             "Response: %s (%s bytes) (rst-%s:rem-%s:used-%s ratelimit) at %s",
@@ -396,6 +397,7 @@ class Session:
 
 
 def session(
+    *,
     authorizer: BaseAuthorizer | None = None,
     window_size: int = WINDOW_SIZE,
 ) -> Session:

--- a/prawcore/util.py
+++ b/prawcore/util.py
@@ -18,6 +18,7 @@ _auth_error_mapping = {
 
 def authorization_error_class(
     response: Response,
+    /,
 ) -> InvalidToken | (Forbidden | InsufficientScope):
     """Return an exception instance that maps to the OAuth Error.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,16 +29,16 @@ def requestor():
 def trusted_authenticator(requestor):
     """Return a TrustedAuthenticator instance."""
     return TrustedAuthenticator(
-        requestor,
-        placeholders.client_id,
-        placeholders.client_secret,
+        client_id=placeholders.client_id,
+        client_secret=placeholders.client_secret,
+        requestor=requestor,
     )
 
 
 @pytest.fixture
 def untrusted_authenticator(requestor):
     """Return an UntrustedAuthenticator instance."""
-    return UntrustedAuthenticator(requestor, placeholders.client_id)
+    return UntrustedAuthenticator(client_id=placeholders.client_id, requestor=requestor)
 
 
 def env_default(key):

--- a/tests/integration/test_authenticator.py
+++ b/tests/integration/test_authenticator.py
@@ -9,30 +9,30 @@ from . import IntegrationTest
 class TestTrustedAuthenticator(IntegrationTest):
     def test_revoke_token(self, requestor):
         authenticator = prawcore.TrustedAuthenticator(
-            requestor,
-            placeholders.client_id,
-            placeholders.client_secret,
+            client_id=placeholders.client_id,
+            client_secret=placeholders.client_secret,
+            requestor=requestor,
         )
         authenticator.revoke_token("dummy token")
 
     def test_revoke_token__with_access_token_hint(self, requestor):
         authenticator = prawcore.TrustedAuthenticator(
-            requestor,
-            placeholders.client_id,
-            placeholders.client_secret,
+            client_id=placeholders.client_id,
+            client_secret=placeholders.client_secret,
+            requestor=requestor,
         )
-        authenticator.revoke_token("dummy token", "access_token")
+        authenticator.revoke_token("dummy token", token_type="access_token")
 
     def test_revoke_token__with_refresh_token_hint(self, requestor):
         authenticator = prawcore.TrustedAuthenticator(
-            requestor,
-            placeholders.client_id,
-            placeholders.client_secret,
+            client_id=placeholders.client_id,
+            client_secret=placeholders.client_secret,
+            requestor=requestor,
         )
-        authenticator.revoke_token("dummy token", "refresh_token")
+        authenticator.revoke_token("dummy token", token_type="refresh_token")
 
 
 class TestUntrustedAuthenticator(IntegrationTest):
     def test_revoke_token(self, requestor):
-        authenticator = prawcore.UntrustedAuthenticator(requestor, placeholders.client_id)
+        authenticator = prawcore.UntrustedAuthenticator(client_id=placeholders.client_id, requestor=requestor)
         authenticator.revoke_token("dummy token")

--- a/tests/integration/test_authorizer.py
+++ b/tests/integration/test_authorizer.py
@@ -11,14 +11,14 @@ from . import IntegrationTest
 class TestAuthorizer(IntegrationTest):
     def test_authorize__with_invalid_code(self, trusted_authenticator):
         trusted_authenticator.redirect_uri = placeholders.redirect_uri
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         with pytest.raises(prawcore.OAuthException):
             authorizer.authorize("invalid code")
         assert not authorizer.is_valid()
 
     def test_authorize__with_permanent_grant(self, trusted_authenticator):
         trusted_authenticator.redirect_uri = placeholders.redirect_uri
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         authorizer.authorize(placeholders.permanent_grant_code)
 
         assert authorizer.access_token is not None
@@ -29,7 +29,7 @@ class TestAuthorizer(IntegrationTest):
 
     def test_authorize__with_temporary_grant(self, trusted_authenticator):
         trusted_authenticator.redirect_uri = placeholders.redirect_uri
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         authorizer.authorize(placeholders.temporary_grant_code)
 
         assert authorizer.access_token is not None
@@ -39,7 +39,7 @@ class TestAuthorizer(IntegrationTest):
         assert authorizer.is_valid()
 
     def test_refresh(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
 
         assert authorizer.access_token is not None
@@ -54,7 +54,7 @@ class TestAuthorizer(IntegrationTest):
             authorizer.refresh_token = "manually_updated"
 
         authorizer = prawcore.Authorizer(
-            trusted_authenticator,
+            authenticator=trusted_authenticator,
             post_refresh_callback=callback,
             refresh_token=placeholders.refresh_token,
         )
@@ -72,7 +72,7 @@ class TestAuthorizer(IntegrationTest):
             assert authorizer.refresh_token is None
             authorizer.refresh_token = placeholders.refresh_token
 
-        authorizer = prawcore.Authorizer(trusted_authenticator, pre_refresh_callback=callback)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, pre_refresh_callback=callback)
         authorizer.refresh()
 
         assert authorizer.access_token is not None
@@ -81,13 +81,13 @@ class TestAuthorizer(IntegrationTest):
         assert authorizer.is_valid()
 
     def test_refresh__with_invalid_token(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token="INVALID_TOKEN")
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token="INVALID_TOKEN")
         with pytest.raises(prawcore.ResponseException):
             authorizer.refresh()
         assert not authorizer.is_valid()
 
     def test_revoke__access_token_with_refresh_set(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
         authorizer.revoke(only_access=True)
 
@@ -102,7 +102,7 @@ class TestAuthorizer(IntegrationTest):
 
     def test_revoke__access_token_without_refresh_set(self, trusted_authenticator):
         trusted_authenticator.redirect_uri = placeholders.redirect_uri
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         authorizer.authorize(placeholders.temporary_grant_code)
         authorizer.revoke()
 
@@ -112,7 +112,7 @@ class TestAuthorizer(IntegrationTest):
         assert not authorizer.is_valid()
 
     def test_revoke__refresh_token_with_access_set(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
         authorizer.revoke()
 
@@ -122,7 +122,7 @@ class TestAuthorizer(IntegrationTest):
         assert not authorizer.is_valid()
 
     def test_revoke__refresh_token_without_access_set(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.revoke()
 
         assert authorizer.access_token is None
@@ -133,7 +133,7 @@ class TestAuthorizer(IntegrationTest):
 
 class TestDeviceIDAuthorizer(IntegrationTest):
     def test_refresh(self, untrusted_authenticator):
-        authorizer = prawcore.DeviceIDAuthorizer(untrusted_authenticator)
+        authorizer = prawcore.DeviceIDAuthorizer(authenticator=untrusted_authenticator)
         authorizer.refresh()
 
         assert authorizer.access_token is not None
@@ -143,10 +143,10 @@ class TestDeviceIDAuthorizer(IntegrationTest):
     def test_refresh__with_scopes_and_trusted_authenticator(self, requestor):
         scope_list = {"adsedit", "adsread", "creddits", "history"}
         authorizer = prawcore.DeviceIDAuthorizer(
-            prawcore.TrustedAuthenticator(
-                requestor,
-                placeholders.client_id,
-                placeholders.client_secret,
+            authenticator=prawcore.TrustedAuthenticator(
+                client_id=placeholders.client_id,
+                client_secret=placeholders.client_secret,
+                requestor=requestor,
             ),
             scopes=scope_list,
         )
@@ -157,14 +157,14 @@ class TestDeviceIDAuthorizer(IntegrationTest):
         assert authorizer.is_valid()
 
     def test_refresh__with_short_device_id(self, untrusted_authenticator):
-        authorizer = prawcore.DeviceIDAuthorizer(untrusted_authenticator, "a" * 19)
+        authorizer = prawcore.DeviceIDAuthorizer(authenticator=untrusted_authenticator, device_id="a" * 19)
         with pytest.raises(prawcore.OAuthException):
             authorizer.refresh()
 
 
 class TestReadOnlyAuthorizer(IntegrationTest):
     def test_refresh(self, trusted_authenticator):
-        authorizer = prawcore.ReadOnlyAuthorizer(trusted_authenticator)
+        authorizer = prawcore.ReadOnlyAuthorizer(authenticator=trusted_authenticator)
         assert authorizer.access_token is None
         assert authorizer.scopes is None
         assert not authorizer.is_valid()
@@ -176,7 +176,7 @@ class TestReadOnlyAuthorizer(IntegrationTest):
 
     def test_refresh__with_scopes(self, trusted_authenticator):
         scope_list = {"adsedit", "adsread", "creddits", "history"}
-        authorizer = prawcore.ReadOnlyAuthorizer(trusted_authenticator, scopes=scope_list)
+        authorizer = prawcore.ReadOnlyAuthorizer(authenticator=trusted_authenticator, scopes=scope_list)
         assert authorizer.access_token is None
         assert authorizer.scopes is None
         assert not authorizer.is_valid()
@@ -190,9 +190,9 @@ class TestReadOnlyAuthorizer(IntegrationTest):
 class TestScriptAuthorizer(IntegrationTest):
     def test_refresh(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
-            trusted_authenticator,
-            placeholders.username,
-            placeholders.password,
+            authenticator=trusted_authenticator,
+            username=placeholders.username,
+            password=placeholders.password,
         )
         assert authorizer.access_token is None
         assert authorizer.scopes is None
@@ -205,17 +205,19 @@ class TestScriptAuthorizer(IntegrationTest):
 
     def test_refresh__with_invalid_otp(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
-            trusted_authenticator,
-            placeholders.username,
-            placeholders.password,
-            lambda: "fake",
+            authenticator=trusted_authenticator,
+            username=placeholders.username,
+            password=placeholders.password,
+            two_factor_callback=lambda: "fake",
         )
         with pytest.raises(prawcore.OAuthException):
             authorizer.refresh()
         assert not authorizer.is_valid()
 
     def test_refresh__with_invalid_username_or_password(self, trusted_authenticator):
-        authorizer = prawcore.ScriptAuthorizer(trusted_authenticator, placeholders.username, "invalidpassword")
+        authorizer = prawcore.ScriptAuthorizer(
+            authenticator=trusted_authenticator, username=placeholders.username, password="invalidpassword"
+        )
         with pytest.raises(prawcore.OAuthException):
             authorizer.refresh()
         assert not authorizer.is_valid()
@@ -223,9 +225,9 @@ class TestScriptAuthorizer(IntegrationTest):
     def test_refresh__with_scopes(self, trusted_authenticator):
         scope_list = {"adsedit", "adsread", "creddits", "history"}
         authorizer = prawcore.ScriptAuthorizer(
-            trusted_authenticator,
-            placeholders.username,
-            placeholders.password,
+            authenticator=trusted_authenticator,
+            username=placeholders.username,
+            password=placeholders.password,
             scopes=scope_list,
         )
         authorizer.refresh()
@@ -236,10 +238,10 @@ class TestScriptAuthorizer(IntegrationTest):
 
     def test_refresh__with_valid_otp(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
-            trusted_authenticator,
-            placeholders.username,
-            placeholders.password,
-            lambda: "000000",
+            authenticator=trusted_authenticator,
+            username=placeholders.username,
+            password=placeholders.password,
+            two_factor_callback=lambda: "000000",
         )
         assert authorizer.access_token is None
         assert authorizer.scopes is None

--- a/tests/integration/test_sessions.py
+++ b/tests/integration/test_sessions.py
@@ -15,23 +15,23 @@ from . import IntegrationTest
 class TestSession(IntegrationTest):
     @pytest.fixture
     def readonly_authorizer(self, trusted_authenticator):
-        authorizer = prawcore.ReadOnlyAuthorizer(trusted_authenticator)
+        authorizer = prawcore.ReadOnlyAuthorizer(authenticator=trusted_authenticator)
         authorizer.refresh()
         return authorizer
 
     @pytest.fixture
     def script_authorizer(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
-            trusted_authenticator,
-            placeholders.username,
-            placeholders.password,
+            authenticator=trusted_authenticator,
+            username=placeholders.username,
+            password=placeholders.password,
         )
         authorizer.refresh()
         return authorizer
 
     def test_request__accepted(self, script_authorizer, caplog):
         caplog.set_level(logging.DEBUG)
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         session.request(method="POST", path="api/read_all_messages")
         found_message = False
         for package, level, message in caplog.record_tuples:
@@ -40,37 +40,37 @@ class TestSession(IntegrationTest):
         assert found_message, f"'Response: 202 (2 bytes)' in {caplog.record_tuples}"
 
     def test_request__bad_gateway(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.ServerError) as exception_info:
             session.request(method="GET", path="/")
         assert exception_info.value.response.status_code == 502
 
     def test_request__bad_json(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         with pytest.raises(prawcore.BadJSON) as exception_info:
             session.request(method="GET", path="/")
         assert len(exception_info.value.response.content) == 92
 
     def test_request__bad_request(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         with pytest.raises(prawcore.BadRequest) as exception_info:
             session.request(method="PUT", path="/api/v1/me/friends/spez", data='{"note": "prawcore"}')
         assert "reason" in exception_info.value.response.json()
 
     def test_request__cloudflare_connection_timed_out(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.ServerError) as exception_info:
             session.request(method="GET", path="/")
         assert exception_info.value.response.status_code == 522
 
     def test_request__cloudflare_unknown_error(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.ServerError) as exception_info:
             session.request(method="GET", path="/")
         assert exception_info.value.response.status_code == 520
 
     def test_request__conflict(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         previous = "f0214574-430d-11e7-84ca-1201093304fa"
         with pytest.raises(prawcore.Conflict) as exception_info:
             session.request(
@@ -85,23 +85,23 @@ class TestSession(IntegrationTest):
         assert exception_info.value.response.status_code == 409
 
     def test_request__created(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         response = session.request(method="PUT", path="/api/v1/me/friends/spez", data="{}")
         assert "name" in response
 
     def test_request__forbidden(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         with pytest.raises(prawcore.Forbidden):
             session.request(method="GET", path="/user/spez/gilded/given")
 
     def test_request__gateway_timeout(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.ServerError) as exception_info:
             session.request(method="GET", path="/")
         assert exception_info.value.response.status_code == 504
 
     def test_request__get(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         params = {"limit": 100}
         response = session.request(method="GET", path="/", params=params)
         assert isinstance(response, dict)
@@ -109,23 +109,23 @@ class TestSession(IntegrationTest):
         assert response["kind"] == "Listing"
 
     def test_request__internal_server_error(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.ServerError) as exception_info:
             session.request(method="GET", path="/")
         assert exception_info.value.response.status_code == 500
 
     def test_request__no_content(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         response = session.request(method="DELETE", path="/api/v1/me/friends/spez")
         assert response is None
 
     def test_request__not_found(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         with pytest.raises(prawcore.NotFound):
             session.request(method="GET", path="/r/reddit_api_test/wiki/invalid")
 
     def test_request__okay_with_0_byte_content(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         data = {"model": dumps({"name": "redditdev"})}
         path = f"/api/multi/user/{placeholders.username}/m/praw_x5g968f66a/r/redditdev"
         response = session.request(method="DELETE", path=path, data=data)
@@ -133,14 +133,14 @@ class TestSession(IntegrationTest):
 
     @pytest.mark.recorder_kwargs(match_on=["method", "uri", "body"])
     def test_request__patch(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         json = {"lang": "ja", "num_comments": 123}
         response = session.request(method="PATCH", path="/api/v1/me/prefs", json=json)
         assert response["lang"] == "ja"
         assert response["num_comments"] == 123
 
     def test_request__post(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         data = {
             "kind": "self",
             "sr": "reddit_api_test",
@@ -153,7 +153,7 @@ class TestSession(IntegrationTest):
         assert key_count == len(data)  # Ensure data is untouched
 
     def test_request__post__with_files(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         data = {"upload_type": "header"}
         with Path("tests/integration/files/white-square.png").open("rb") as fp:
             files = {"file": fp}
@@ -166,7 +166,7 @@ class TestSession(IntegrationTest):
         assert "img_src" in response
 
     def test_request__raw_json(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         response = session.request(
             method="GET",
             path="/r/reddit_api_test/comments/45xjdr/want_raw_json_test/",
@@ -174,25 +174,25 @@ class TestSession(IntegrationTest):
         assert response[0]["data"]["children"][0]["data"]["title"] == "WANT_RAW_JSON test: < > &"
 
     def test_request__redirect(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.Redirect) as exception_info:
             session.request(method="GET", path="/r/random")
         assert exception_info.value.path.startswith("/r/")
 
     def test_request__redirect_301(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.Redirect) as exception_info:
             session.request(method="GET", path="t/bird")
         assert exception_info.value.path == "/r/t:bird/"
 
     def test_request__service_unavailable(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.ServerError) as exception_info:
             session.request(method="GET", path="/")
         assert exception_info.value.response.status_code == 503
 
     def test_request__too__many_requests__with_retry_headers(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         session.requestor._http.headers.update({"User-Agent": "python-requests/2.25.1"})
         with pytest.raises(prawcore.TooManyRequests) as exception_info:
             session.request(method="GET", path="/api/v1/me")
@@ -205,10 +205,10 @@ class TestSession(IntegrationTest):
     def test_request__too__many_requests__without_retry_headers(self, requestor):
         requestor._http.headers.update({"User-Agent": "python-requests/2.25.1"})
         authorizer = prawcore.ReadOnlyAuthorizer(
-            prawcore.TrustedAuthenticator(
-                requestor,
-                placeholders.client_id,
-                placeholders.client_secret,
+            authenticator=prawcore.TrustedAuthenticator(
+                client_id=placeholders.client_id,
+                client_secret=placeholders.client_secret,
+                requestor=requestor,
             ),
         )
         with pytest.raises(prawcore.exceptions.ResponseException) as exception_info:
@@ -222,7 +222,7 @@ class TestSession(IntegrationTest):
         }
 
     def test_request__too_large(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         data = {"upload_type": "header"}
         with Path("tests/integration/files/too_large.jpg").open("rb") as fp:
             files = {"file": fp}
@@ -236,19 +236,19 @@ class TestSession(IntegrationTest):
         assert exception_info.value.response.status_code == 413
 
     def test_request__unavailable_for_legal_reasons(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         with pytest.raises(prawcore.UnavailableForLegalReasons) as exception_info:
             session.request(method="GET", path="/")
         assert exception_info.value.response.status_code == 451
 
     def test_request__unexpected_status_code(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         with pytest.raises(prawcore.ResponseException) as exception_info:
             session.request(method="DELETE", path="/api/v1/me/friends/spez")
         assert exception_info.value.response.status_code == 205
 
     def test_request__unsupported_media_type(self, script_authorizer):
-        session = prawcore.Session(script_authorizer)
+        session = prawcore.Session(authorizer=script_authorizer)
         data = {
             "content": "type: submission\naction: upvote",
             "page": "config/automoderator",
@@ -258,7 +258,7 @@ class TestSession(IntegrationTest):
         assert exception_info.value.response.status_code == 415
 
     def test_request__uri_too_long(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         path_start = "/api/morechildren?link_id=t3_n7r3uz&children="
         ids = Path("tests/integration/files/comment_ids.txt").read_text()
         with pytest.raises(prawcore.URITooLong) as exception_info:
@@ -266,9 +266,9 @@ class TestSession(IntegrationTest):
         assert exception_info.value.response.status_code == 414
 
     def test_request__with_insufficient_scope(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token=placeholders.refresh_token)
         authorizer.refresh()
-        session = prawcore.Session(authorizer)
+        session = prawcore.Session(authorizer=authorizer)
         with pytest.raises(prawcore.InsufficientScope):
             session.request(
                 method="GET",
@@ -276,14 +276,16 @@ class TestSession(IntegrationTest):
             )
 
     def test_request__with_invalid_access_token(self, untrusted_authenticator):
-        authorizer = prawcore.ImplicitAuthorizer(untrusted_authenticator, None, 0, "")
-        session = prawcore.Session(authorizer)
+        authorizer = prawcore.ImplicitAuthorizer(
+            access_token=None, authenticator=untrusted_authenticator, expires_in=0, scope=""
+        )
+        session = prawcore.Session(authorizer=authorizer)
         session._authorizer.access_token = "invalid"
         with pytest.raises(prawcore.InvalidToken):
             session.request(method="get", path="/")
 
     def test_request__with_invalid_access_token__retry(self, readonly_authorizer):
-        session = prawcore.Session(readonly_authorizer)
+        session = prawcore.Session(authorizer=readonly_authorizer)
         session._authorizer.access_token += "invalid"
         response = session.request(method="GET", path="/")
         assert isinstance(response, dict)

--- a/tests/unit/test_authorizer.py
+++ b/tests/unit/test_authorizer.py
@@ -14,86 +14,92 @@ class InvalidAuthenticator(prawcore.auth.BaseAuthenticator):
 
 class TestAuthorizer(UnitTest):
     def test_authenticator(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         assert authorizer.authenticator is trusted_authenticator
 
     def test_authorize__fail_without_redirect_uri(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         with pytest.raises(prawcore.InvalidInvocation):
             authorizer.authorize("dummy code")
         assert not authorizer.is_valid()
 
     def test_initialize(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         assert authorizer.access_token is None
         assert authorizer.scopes is None
         assert authorizer.refresh_token is None
         assert not authorizer.is_valid()
 
     def test_initialize__with_refresh_token(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token=placeholders.refresh_token)
         assert authorizer.access_token is None
         assert authorizer.scopes is None
         assert placeholders.refresh_token == authorizer.refresh_token
         assert not authorizer.is_valid()
 
     def test_initialize__with_untrusted_authenticator(self):
-        authenticator = prawcore.UntrustedAuthenticator(None, None)
-        authorizer = prawcore.Authorizer(authenticator)
+        authenticator = prawcore.UntrustedAuthenticator(client_id=None, requestor=None)
+        authorizer = prawcore.Authorizer(authenticator=authenticator)
         assert authorizer.access_token is None
         assert authorizer.scopes is None
         assert authorizer.refresh_token is None
         assert not authorizer.is_valid()
 
     def test_refresh__without_refresh_token(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         with pytest.raises(prawcore.InvalidInvocation):
             authorizer.refresh()
         assert not authorizer.is_valid()
 
     def test_revoke__without_access_token(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator, refresh_token=placeholders.refresh_token)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator, refresh_token=placeholders.refresh_token)
         with pytest.raises(prawcore.InvalidInvocation):
             authorizer.revoke(only_access=True)
 
     def test_revoke__without_any_token(self, trusted_authenticator):
-        authorizer = prawcore.Authorizer(trusted_authenticator)
+        authorizer = prawcore.Authorizer(authenticator=trusted_authenticator)
         with pytest.raises(prawcore.InvalidInvocation):
             authorizer.revoke()
 
 
 class TestDeviceIDAuthorizer(UnitTest):
     def test_initialize(self, untrusted_authenticator):
-        authorizer = prawcore.DeviceIDAuthorizer(untrusted_authenticator)
+        authorizer = prawcore.DeviceIDAuthorizer(authenticator=untrusted_authenticator)
         assert authorizer.access_token is None
         assert authorizer.scopes is None
         assert not authorizer.is_valid()
 
     def test_initialize__with_invalid_authenticator(self):
-        authenticator = prawcore.Authorizer(InvalidAuthenticator(None, None, None))
+        authenticator = prawcore.Authorizer(
+            authenticator=InvalidAuthenticator(client_id=None, redirect_uri=None, requestor=None)
+        )
         with pytest.raises(prawcore.InvalidInvocation):
-            prawcore.DeviceIDAuthorizer(authenticator)
+            prawcore.DeviceIDAuthorizer(authenticator=authenticator)
 
 
 class TestImplicitAuthorizer(UnitTest):
     def test_initialize(self, untrusted_authenticator):
-        authorizer = prawcore.ImplicitAuthorizer(untrusted_authenticator, "fake token", 1, "modposts read")
+        authorizer = prawcore.ImplicitAuthorizer(
+            access_token="fake token", authenticator=untrusted_authenticator, expires_in=1, scope="modposts read"
+        )
         assert authorizer.access_token == "fake token"
         assert authorizer.scopes == {"modposts", "read"}
         assert authorizer.is_valid()
 
     def test_initialize__with_trusted_authenticator(self, trusted_authenticator):
         with pytest.raises(prawcore.InvalidInvocation):
-            prawcore.ImplicitAuthorizer(trusted_authenticator, None, None, None)
+            prawcore.ImplicitAuthorizer(
+                access_token=None, authenticator=trusted_authenticator, expires_in=None, scope=None
+            )
 
 
 class TestReadOnlyAuthorizer(UnitTest):
     def test_initialize__with_untrusted_authenticator(self, untrusted_authenticator):
         with pytest.raises(prawcore.InvalidInvocation):
-            prawcore.ReadOnlyAuthorizer(untrusted_authenticator)
+            prawcore.ReadOnlyAuthorizer(authenticator=untrusted_authenticator)
 
 
 class TestScriptAuthorizer(UnitTest):
     def test_initialize__with_untrusted_authenticator(self, untrusted_authenticator):
         with pytest.raises(prawcore.InvalidInvocation):
-            prawcore.ScriptAuthorizer(untrusted_authenticator, None, None)
+            prawcore.ScriptAuthorizer(authenticator=untrusted_authenticator, username=None, password=None)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -59,7 +59,7 @@ class TestRateLimiter(UnitTest):
     @patch("time.monotonic_ns")
     def test_update__compute_delay_with_no_previous_info(self, mock_monotonic_ns, rate_limiter):
         mock_monotonic_ns.return_value = 100 * NANOSECONDS
-        rate_limiter.update(self._headers(60, 100, 60))
+        rate_limiter.update(response_headers=self._headers(60, 100, 60))
         assert rate_limiter.remaining == 60
         assert rate_limiter.used == 100
         assert rate_limiter.next_request_timestamp_ns == 100 * NANOSECONDS
@@ -68,7 +68,7 @@ class TestRateLimiter(UnitTest):
     def test_update__compute_delay_with_single_client(self, mock_monotonic_ns, rate_limiter):
         rate_limiter.window_size = 150
         mock_monotonic_ns.return_value = 100 * NANOSECONDS
-        rate_limiter.update(self._headers(50, 100, 60))
+        rate_limiter.update(response_headers=self._headers(50, 100, 60))
         assert rate_limiter.remaining == 50
         assert rate_limiter.used == 100
         assert rate_limiter.next_request_timestamp_ns == 110 * NANOSECONDS
@@ -78,7 +78,7 @@ class TestRateLimiter(UnitTest):
         rate_limiter.remaining = 66
         rate_limiter.window_size = 180
         mock_monotonic_ns.return_value = 100 * NANOSECONDS
-        rate_limiter.update(self._headers(60, 100, 72))
+        rate_limiter.update(response_headers=self._headers(60, 100, 72))
         assert rate_limiter.remaining == 60
         assert rate_limiter.used == 100
         assert rate_limiter.next_request_timestamp_ns == 104.5 * NANOSECONDS
@@ -86,7 +86,7 @@ class TestRateLimiter(UnitTest):
     @patch("time.monotonic_ns")
     def test_update__delay_full_time_with_negative_remaining(self, mock_monotonic_ns, rate_limiter):
         mock_monotonic_ns.return_value = 37 * NANOSECONDS
-        rate_limiter.update(self._headers(0, 100, 13))
+        rate_limiter.update(response_headers=self._headers(0, 100, 13))
         assert rate_limiter.remaining == 0
         assert rate_limiter.used == 100
         assert rate_limiter.next_request_timestamp_ns == 50 * NANOSECONDS
@@ -94,7 +94,7 @@ class TestRateLimiter(UnitTest):
     @patch("time.monotonic_ns")
     def test_update__delay_full_time_with_zero_remaining(self, mock_monotonic_ns, rate_limiter):
         mock_monotonic_ns.return_value = 37 * NANOSECONDS
-        rate_limiter.update(self._headers(0, 100, 13))
+        rate_limiter.update(response_headers=self._headers(0, 100, 13))
         assert rate_limiter.remaining == 0
         assert rate_limiter.used == 100
         assert rate_limiter.next_request_timestamp_ns == 50 * NANOSECONDS
@@ -102,14 +102,14 @@ class TestRateLimiter(UnitTest):
     @patch("time.monotonic_ns")
     def test_update__delay_full_time_with_zero_remaining_and_no_sleep_time(self, mock_monotonic_ns, rate_limiter):
         mock_monotonic_ns.return_value = 37 * NANOSECONDS
-        rate_limiter.update(self._headers(0, 100, 0))
+        rate_limiter.update(response_headers=self._headers(0, 100, 0))
         assert rate_limiter.remaining == 0
         assert rate_limiter.used == 100
         assert rate_limiter.next_request_timestamp_ns == 38 * NANOSECONDS
 
     def test_update__no_change_without_headers(self, rate_limiter):
         prev = copy(rate_limiter)
-        rate_limiter.update({})
+        rate_limiter.update(response_headers={})
         assert prev.remaining == rate_limiter.remaining
         assert prev.used == rate_limiter.used
         assert rate_limiter.next_request_timestamp_ns == prev.next_request_timestamp_ns
@@ -117,6 +117,6 @@ class TestRateLimiter(UnitTest):
     def test_update__values_change_without_headers(self, rate_limiter):
         rate_limiter.remaining = 10
         rate_limiter.used = 99
-        rate_limiter.update({})
+        rate_limiter.update(response_headers={})
         assert rate_limiter.remaining == 9
         assert rate_limiter.used == 100

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -18,10 +18,10 @@ from . import UnitTest
 class InvalidAuthorizer(prawcore.Authorizer):
     def __init__(self, requestor):
         super().__init__(
-            prawcore.TrustedAuthenticator(
-                requestor,
-                placeholders.client_id,
-                placeholders.client_secret,
+            authenticator=prawcore.TrustedAuthenticator(
+                client_id=placeholders.client_id,
+                client_secret=placeholders.client_secret,
+                requestor=requestor,
             ),
         )
 
@@ -32,33 +32,35 @@ class InvalidAuthorizer(prawcore.Authorizer):
 class TestSession(UnitTest):
     @pytest.fixture
     def readonly_authorizer(self, trusted_authenticator):
-        return prawcore.ReadOnlyAuthorizer(trusted_authenticator)
+        return prawcore.ReadOnlyAuthorizer(authenticator=trusted_authenticator)
 
     def test_accessors(self, requestor, trusted_authenticator):
-        authorizer = prawcore.ReadOnlyAuthorizer(trusted_authenticator)
-        session = prawcore.Session(authorizer)
+        authorizer = prawcore.ReadOnlyAuthorizer(authenticator=trusted_authenticator)
+        session = prawcore.Session(authorizer=authorizer)
         assert session.authorizer is authorizer
         assert isinstance(session.rate_limiter, RateLimiter)
         assert session.requestor is requestor
 
     def test_close(self, readonly_authorizer):
-        prawcore.Session(readonly_authorizer).close()
+        prawcore.Session(authorizer=readonly_authorizer).close()
 
     def test_context_manager(self, readonly_authorizer):
-        with prawcore.Session(readonly_authorizer) as session:
+        with prawcore.Session(authorizer=readonly_authorizer) as session:
             assert isinstance(session, prawcore.Session)
 
     def test_init__with_device_id_authorizer(self, untrusted_authenticator):
-        authorizer = prawcore.DeviceIDAuthorizer(untrusted_authenticator)
-        prawcore.Session(authorizer)
+        authorizer = prawcore.DeviceIDAuthorizer(authenticator=untrusted_authenticator)
+        prawcore.Session(authorizer=authorizer)
 
     def test_init__with_implicit_authorizer(self, untrusted_authenticator):
-        authorizer = prawcore.ImplicitAuthorizer(untrusted_authenticator, None, 0, "")
-        prawcore.Session(authorizer)
+        authorizer = prawcore.ImplicitAuthorizer(
+            access_token=None, authenticator=untrusted_authenticator, expires_in=0, scope=""
+        )
+        prawcore.Session(authorizer=authorizer)
 
     def test_init__without_authenticator(self):
         with pytest.raises(prawcore.InvalidInvocation):
-            prawcore.Session(None)
+            prawcore.Session(authorizer=None)
 
     @patch("requests.Session")
     @pytest.mark.parametrize(
@@ -78,18 +80,18 @@ class TestSession(UnitTest):
         session_instance.request.return_value = Mock(headers={}, json=lambda: response_dict, status_code=200)
         requestor = prawcore.Requestor(user_agent="prawcore:test (by /u/bboe)")
         authenticator = prawcore.TrustedAuthenticator(
-            requestor,
-            placeholders.client_id,
-            placeholders.client_secret,
+            client_id=placeholders.client_id,
+            client_secret=placeholders.client_secret,
+            requestor=requestor,
         )
-        authorizer = prawcore.ReadOnlyAuthorizer(authenticator)
+        authorizer = prawcore.ReadOnlyAuthorizer(authenticator=authenticator)
         authorizer.refresh()
         session_instance.request.reset_mock()
         # Fail on subsequent request
         session_instance.request.side_effect = exception
 
         with pytest.raises(RequestException) as exception_info:
-            prawcore.Session(authorizer).request(method="GET", path="/")
+            prawcore.Session(authorizer=authorizer).request(method="GET", path="/")
         assert (
             "prawcore",
             logging.WARNING,
@@ -100,14 +102,14 @@ class TestSession(UnitTest):
         assert session_instance.request.call_count == 3
 
     def test_request__with_invalid_authorizer(self, requestor):
-        session = prawcore.Session(InvalidAuthorizer(requestor))
+        session = prawcore.Session(authorizer=InvalidAuthorizer(requestor))
         with pytest.raises(prawcore.InvalidInvocation):
             session.request(method="get", path="/")
 
 
 class TestSessionFunction(UnitTest):
     def test_session(self, requestor):
-        assert isinstance(prawcore.session(InvalidAuthorizer(requestor)), prawcore.Session)
+        assert isinstance(prawcore.session(authorizer=InvalidAuthorizer(requestor)), prawcore.Session)
 
 
 class TestFiniteRetryStrategy(UnitTest):


### PR DESCRIPTION
Completes the keyword-only/positional-only API redesign for the next major release:
every public parameter is now either positional-only (`/`) or keyword-only (`*`), with
positional-only reserved for a single obvious operand.

## What changed

- **Keyword-only** — the `requestor`, `authenticator`, and `authorizer` subject objects of
  the authenticator/authorizer classes, all of their other parameters, the `session`
  factory, and `Session` itself are now keyword-only (arguments sorted alphabetically).
- **Positional-only (`/`)** — the single obvious operand of a function: the `token` of
  `BaseAuthenticator.revoke_token`, the `code` of `Authorizer.authorize`, and the
  `response` of the exception classes.
- Builds on the already-merged keyword-only changes to `Session.request`, `Requestor`,
  `BaseAuthenticator.authorize_url`, and `Authorizer.revoke`; the consolidated changelog
  entry now describes the whole redesign in one place.

## Migration

```python
prawcore.TrustedAuthenticator(requestor=requestor, client_id=..., client_secret=...)
prawcore.ReadOnlyAuthorizer(authenticator=authenticator)
prawcore.session(authorizer=authorizer)
```

## Verification

`ruff check .`, `ruff format --check .`, and `pyright prawcore` clean; full test suite
green (111 passed).

This is a breaking change and warrants a major version bump on release.
