### PR TITLE
Run Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: quarterly
+      interval: monthly
     labels:
       - "Dependencies"
   - package-ecosystem: uv
     directory: /
     schedule:
-      interval: quarterly
+      interval: monthly
     labels:
       - "Dependencies"


### PR DESCRIPTION
Standardize the Dependabot schedule to a monthly interval across all repositories.