### PR TITLE
Adopt the CodeSorter pre-commit hook and sort the source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: codesorter
         require_serial: true
     repo: https://github.com/praw-dev/CodeSorter
-    rev: 33c79d5c2fab0b6f1a6850c97f92da1739951f2d  # frozen: v0.1.0
+    rev: 2eaa2ef4f23a9ac80dc51a1792ad74c783144419  # frozen: v0.2.6
 
   - hooks:
       - id: auto-walrus

--- a/examples/caching_requestor.py
+++ b/examples/caching_requestor.py
@@ -16,13 +16,36 @@ import requests
 import prawcore
 
 
+class CachingSession(requests.Session):
+    """Cache GETs in memory.
+
+    Toy example of custom session to showcase the ``session`` parameter of
+    :class:`.Requestor`.
+
+    """
+
+    get_cache: ClassVar = {}
+
+    def request(self, method, url, params=None, **kwargs):
+        """Perform a request, or return a cached response if available."""
+        params_key = tuple(params.items()) if params else ()
+        if method.upper() == "GET" and (url, params_key) in self.get_cache:
+            print("Returning cached response for:", method, url, params)
+            return self.get_cache[url, params_key]
+        result = super().request(method, url, params, **kwargs)
+        if method.upper() == "GET":
+            self.get_cache[url, params_key] = result
+            print("Adding entry to the cache:", method, url, params)
+        return result
+
+
 def main():
     """Provide the program's entry point when directly executed."""
     if len(sys.argv) != 2:
         print(f"Usage: {sys.argv[0]} USERNAME")
         return 1
 
-    caching_requestor = prawcore.Requestor(user_agent="prawcore_device_id_auth_example", session=CachingSession())
+    caching_requestor = prawcore.Requestor(session=CachingSession(), user_agent="prawcore_device_id_auth_example")
     authenticator = prawcore.TrustedAuthenticator(
         client_id=os.environ["PRAWCORE_CLIENT_ID"],
         client_secret=os.environ["PRAWCORE_CLIENT_SECRET"],
@@ -57,29 +80,6 @@ def main():
     )
 
     return 0
-
-
-class CachingSession(requests.Session):
-    """Cache GETs in memory.
-
-    Toy example of custom session to showcase the ``session`` parameter of
-    :class:`.Requestor`.
-
-    """
-
-    get_cache: ClassVar = {}
-
-    def request(self, method, url, params=None, **kwargs):
-        """Perform a request, or return a cached response if available."""
-        params_key = tuple(params.items()) if params else ()
-        if method.upper() == "GET" and (url, params_key) in self.get_cache:
-            print("Returning cached response for:", method, url, params)
-            return self.get_cache[url, params_key]
-        result = super().request(method, url, params, **kwargs)
-        if method.upper() == "GET":
-            self.get_cache[url, params_key] = result
-            print("Adding entry to the cache:", method, url, params)
-        return result
 
 
 if __name__ == "__main__":

--- a/examples/script_auth_friend_list.py
+++ b/examples/script_auth_friend_list.py
@@ -23,8 +23,8 @@ def main():
     )
     authorizer = prawcore.ScriptAuthorizer(
         authenticator=authenticator,
-        username=os.environ["PRAWCORE_USERNAME"],
         password=os.environ["PRAWCORE_PASSWORD"],
+        username=os.environ["PRAWCORE_USERNAME"],
     )
     authorizer.refresh()
 

--- a/prawcore/__init__.py
+++ b/prawcore/__init__.py
@@ -18,8 +18,6 @@ from prawcore.sessions import Session, session
 
 logging.getLogger(__package__).addHandler(logging.NullHandler())
 
-__version__ = "4.0.1.dev0"
-
 __all__ = [
     "Authorizer",
     "DeviceIDAuthorizer",
@@ -33,3 +31,5 @@ __all__ = [
     "session",
 ]
 __all__ += exceptions.__all__
+
+__version__ = "4.0.1.dev0"

--- a/prawcore/auth.py
+++ b/prawcore/auth.py
@@ -196,45 +196,6 @@ class BaseAuthorizer:
         self._clear_access_token()
 
 
-class TrustedAuthenticator(BaseAuthenticator):
-    """Store OAuth2 authentication credentials for web, or script type apps."""
-
-    RESPONSE_TYPE: str = "code"
-
-    def __init__(
-        self,
-        *,
-        client_id: str,
-        client_secret: str,
-        redirect_uri: str | None = None,
-        requestor: Requestor,
-    ) -> None:
-        """Represent a single authentication to Reddit's API.
-
-        :param client_id: The OAuth2 client ID to use with the session.
-        :param client_secret: The OAuth2 client secret to use with the session.
-        :param redirect_uri: The redirect URI exactly as specified in your OAuth
-            application settings on Reddit. This parameter is required if you want to
-            use the :meth:`~.Authorizer.authorize_url` method, or the
-            :meth:`~.Authorizer.authorize` method of the :class:`.Authorizer` class
-            (default: ``None``).
-        :param requestor: An instance of :class:`.Requestor`.
-
-        """
-        super().__init__(client_id=client_id, redirect_uri=redirect_uri, requestor=requestor)
-        self.client_secret = client_secret
-
-    def _auth(self) -> tuple[str, str]:
-        return self.client_id, self.client_secret
-
-
-class UntrustedAuthenticator(BaseAuthenticator):
-    """Store OAuth2 authentication credentials for installed applications."""
-
-    def _auth(self) -> tuple[str, str]:
-        return self.client_id, ""
-
-
 class Authorizer(BaseAuthorizer):
     """Manages OAuth2 authorization tokens and scopes."""
 
@@ -312,37 +273,36 @@ class Authorizer(BaseAuthorizer):
             self.refresh_token = None
 
 
-class ImplicitAuthorizer(BaseAuthorizer):
-    """Manages implicit installed-app type authorizations."""
+class TrustedAuthenticator(BaseAuthenticator):
+    """Store OAuth2 authentication credentials for web, or script type apps."""
 
-    AUTHENTICATOR_CLASS = UntrustedAuthenticator
+    RESPONSE_TYPE: str = "code"
 
     def __init__(
         self,
         *,
-        access_token: str,
-        authenticator: UntrustedAuthenticator,
-        expires_in: int,
-        scope: str,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str | None = None,
+        requestor: Requestor,
     ) -> None:
-        """Represent a single implicit authorization to Reddit's API.
+        """Represent a single authentication to Reddit's API.
 
-        :param access_token: The ``access_token`` obtained from Reddit via callback to
-            the authenticator's ``redirect_uri``.
-        :param authenticator: An instance of :class:`.UntrustedAuthenticator`.
-        :param expires_in: The number of seconds the ``access_token`` is valid for. The
-            origin of this value was returned from Reddit via callback to the
-            authenticator's redirect uri. Note, you may need to subtract an offset
-            before passing in this number to account for a delay between when Reddit
-            prepared the response, and when you make this function call.
-        :param scope: A space-delimited string of Reddit OAuth2 scope names as returned
-            from Reddit in the callback to the authenticator's redirect uri.
+        :param client_id: The OAuth2 client ID to use with the session.
+        :param client_secret: The OAuth2 client secret to use with the session.
+        :param redirect_uri: The redirect URI exactly as specified in your OAuth
+            application settings on Reddit. This parameter is required if you want to
+            use the :meth:`~.Authorizer.authorize_url` method, or the
+            :meth:`~.Authorizer.authorize` method of the :class:`.Authorizer` class
+            (default: ``None``).
+        :param requestor: An instance of :class:`.Requestor`.
 
         """
-        super().__init__(authenticator=authenticator)
-        self._expiration_timestamp_ns = time.monotonic_ns() + expires_in * const.NANOSECONDS
-        self.access_token = access_token
-        self.scopes = set(scope.split(" "))
+        super().__init__(client_id=client_id, redirect_uri=redirect_uri, requestor=requestor)
+        self.client_secret = client_secret
+
+    def _auth(self) -> tuple[str, str]:
+        return self.client_id, self.client_secret
 
 
 class ReadOnlyAuthorizer(Authorizer):
@@ -425,10 +385,17 @@ class ScriptAuthorizer(Authorizer):
             additional_kwargs["otp"] = two_factor_code
         self._request_token(
             grant_type="password",
-            username=self._username,
             password=self._password,
+            username=self._username,
             **additional_kwargs,
         )
+
+
+class UntrustedAuthenticator(BaseAuthenticator):
+    """Store OAuth2 authentication credentials for installed applications."""
+
+    def _auth(self) -> tuple[str, str]:
+        return self.client_id, ""
 
 
 class DeviceIDAuthorizer(BaseAuthorizer):
@@ -473,7 +440,40 @@ class DeviceIDAuthorizer(BaseAuthorizer):
             additional_kwargs["scope"] = " ".join(self._scopes)
         grant_type = "https://oauth.reddit.com/grants/installed_client"
         self._request_token(
-            grant_type=grant_type,
             device_id=self._device_id,
+            grant_type=grant_type,
             **additional_kwargs,
         )
+
+
+class ImplicitAuthorizer(BaseAuthorizer):
+    """Manages implicit installed-app type authorizations."""
+
+    AUTHENTICATOR_CLASS = UntrustedAuthenticator
+
+    def __init__(
+        self,
+        *,
+        access_token: str,
+        authenticator: UntrustedAuthenticator,
+        expires_in: int,
+        scope: str,
+    ) -> None:
+        """Represent a single implicit authorization to Reddit's API.
+
+        :param access_token: The ``access_token`` obtained from Reddit via callback to
+            the authenticator's ``redirect_uri``.
+        :param authenticator: An instance of :class:`.UntrustedAuthenticator`.
+        :param expires_in: The number of seconds the ``access_token`` is valid for. The
+            origin of this value was returned from Reddit via callback to the
+            authenticator's redirect uri. Note, you may need to subtract an offset
+            before passing in this number to account for a delay between when Reddit
+            prepared the response, and when you make this function call.
+        :param scope: A space-delimited string of Reddit OAuth2 scope names as returned
+            from Reddit in the callback to the authenticator's redirect uri.
+
+        """
+        super().__init__(authenticator=authenticator)
+        self._expiration_timestamp_ns = time.monotonic_ns() + expires_in * const.NANOSECONDS
+        self.access_token = access_token
+        self.scopes = set(scope.split(" "))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,23 @@ import pytest
 from prawcore import Requestor, TrustedAuthenticator, UntrustedAuthenticator
 
 
+class Placeholders:
+    access_token: str
+    basic_auth: str
+    client_id: str
+    client_secret: str
+    password: str
+    permanent_grant_code: str
+    redirect_uri: str
+    refresh_token: str
+    temporary_grant_code: str
+    user_agent: str
+    username: str
+
+    def __init__(self, _dict):
+        self.__dict__ = _dict
+
+
 @pytest.fixture(autouse=True)
 def patch_sleep(monkeypatch):
     """Auto patch sleep to speed up tests."""
@@ -49,28 +66,6 @@ def env_default(key):
     )
 
 
-def pytest_configure(config):
-    config.addinivalue_line("markers", "cassette_name: Name of cassette to use for test.")
-    config.addinivalue_line("markers", "recorder_kwargs: Arguments to pass to the recorder.")
-
-
-class Placeholders:
-    access_token: str
-    basic_auth: str
-    client_id: str
-    client_secret: str
-    password: str
-    permanent_grant_code: str
-    redirect_uri: str
-    refresh_token: str
-    temporary_grant_code: str
-    user_agent: str
-    username: str
-
-    def __init__(self, _dict):
-        self.__dict__ = _dict
-
-
 placeholder_values = {
     x: env_default(x)
     for x in [
@@ -85,6 +80,12 @@ placeholder_values = {
         "username",
     ]
 }
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "cassette_name: Name of cassette to use for test.")
+    config.addinivalue_line("markers", "recorder_kwargs: Arguments to pass to the recorder.")
+
 
 if (
     placeholder_values["client_id"] != "fake_client_id" and placeholder_values["client_secret"] == "fake_client_secret"

--- a/tests/integration/test_authorizer.py
+++ b/tests/integration/test_authorizer.py
@@ -191,8 +191,8 @@ class TestScriptAuthorizer(IntegrationTest):
     def test_refresh(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             authenticator=trusted_authenticator,
-            username=placeholders.username,
             password=placeholders.password,
+            username=placeholders.username,
         )
         assert authorizer.access_token is None
         assert authorizer.scopes is None
@@ -206,9 +206,9 @@ class TestScriptAuthorizer(IntegrationTest):
     def test_refresh__with_invalid_otp(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             authenticator=trusted_authenticator,
-            username=placeholders.username,
             password=placeholders.password,
             two_factor_callback=lambda: "fake",
+            username=placeholders.username,
         )
         with pytest.raises(prawcore.OAuthException):
             authorizer.refresh()
@@ -216,7 +216,7 @@ class TestScriptAuthorizer(IntegrationTest):
 
     def test_refresh__with_invalid_username_or_password(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
-            authenticator=trusted_authenticator, username=placeholders.username, password="invalidpassword"
+            authenticator=trusted_authenticator, password="invalidpassword", username=placeholders.username
         )
         with pytest.raises(prawcore.OAuthException):
             authorizer.refresh()
@@ -226,9 +226,9 @@ class TestScriptAuthorizer(IntegrationTest):
         scope_list = {"adsedit", "adsread", "creddits", "history"}
         authorizer = prawcore.ScriptAuthorizer(
             authenticator=trusted_authenticator,
-            username=placeholders.username,
             password=placeholders.password,
             scopes=scope_list,
+            username=placeholders.username,
         )
         authorizer.refresh()
 
@@ -239,9 +239,9 @@ class TestScriptAuthorizer(IntegrationTest):
     def test_refresh__with_valid_otp(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             authenticator=trusted_authenticator,
-            username=placeholders.username,
             password=placeholders.password,
             two_factor_callback=lambda: "000000",
+            username=placeholders.username,
         )
         assert authorizer.access_token is None
         assert authorizer.scopes is None

--- a/tests/integration/test_sessions.py
+++ b/tests/integration/test_sessions.py
@@ -23,8 +23,8 @@ class TestSession(IntegrationTest):
     def script_authorizer(self, trusted_authenticator):
         authorizer = prawcore.ScriptAuthorizer(
             authenticator=trusted_authenticator,
-            username=placeholders.username,
             password=placeholders.password,
+            username=placeholders.username,
         )
         authorizer.refresh()
         return authorizer
@@ -54,7 +54,7 @@ class TestSession(IntegrationTest):
     def test_request__bad_request(self, script_authorizer):
         session = prawcore.Session(authorizer=script_authorizer)
         with pytest.raises(prawcore.BadRequest) as exception_info:
-            session.request(method="PUT", path="/api/v1/me/friends/spez", data='{"note": "prawcore"}')
+            session.request(data='{"note": "prawcore"}', method="PUT", path="/api/v1/me/friends/spez")
         assert "reason" in exception_info.value.response.json()
 
     def test_request__cloudflare_connection_timed_out(self, readonly_authorizer):
@@ -74,19 +74,19 @@ class TestSession(IntegrationTest):
         previous = "f0214574-430d-11e7-84ca-1201093304fa"
         with pytest.raises(prawcore.Conflict) as exception_info:
             session.request(
-                method="POST",
-                path="/r/ThirdRealm/api/wiki/edit",
                 data={
                     "content": "New text",
                     "page": "index",
                     "previous": previous,
                 },
+                method="POST",
+                path="/r/ThirdRealm/api/wiki/edit",
             )
         assert exception_info.value.response.status_code == 409
 
     def test_request__created(self, script_authorizer):
         session = prawcore.Session(authorizer=script_authorizer)
-        response = session.request(method="PUT", path="/api/v1/me/friends/spez", data="{}")
+        response = session.request(data="{}", method="PUT", path="/api/v1/me/friends/spez")
         assert "name" in response
 
     def test_request__forbidden(self, script_authorizer):
@@ -103,7 +103,7 @@ class TestSession(IntegrationTest):
     def test_request__get(self, readonly_authorizer):
         session = prawcore.Session(authorizer=readonly_authorizer)
         params = {"limit": 100}
-        response = session.request(method="GET", path="/", params=params)
+        response = session.request(method="GET", params=params, path="/")
         assert isinstance(response, dict)
         assert len(params) == 1
         assert response["kind"] == "Listing"
@@ -128,14 +128,14 @@ class TestSession(IntegrationTest):
         session = prawcore.Session(authorizer=script_authorizer)
         data = {"model": dumps({"name": "redditdev"})}
         path = f"/api/multi/user/{placeholders.username}/m/praw_x5g968f66a/r/redditdev"
-        response = session.request(method="DELETE", path=path, data=data)
+        response = session.request(data=data, method="DELETE", path=path)
         assert response == ""
 
     @pytest.mark.recorder_kwargs(match_on=["method", "uri", "body"])
     def test_request__patch(self, script_authorizer):
         session = prawcore.Session(authorizer=script_authorizer)
         json = {"lang": "ja", "num_comments": 123}
-        response = session.request(method="PATCH", path="/api/v1/me/prefs", json=json)
+        response = session.request(json=json, method="PATCH", path="/api/v1/me/prefs")
         assert response["lang"] == "ja"
         assert response["num_comments"] == 123
 
@@ -148,7 +148,7 @@ class TestSession(IntegrationTest):
             "title": "A Test from PRAWCORE.",
         }
         key_count = len(data)
-        response = session.request(method="POST", path="/api/submit", data=data)
+        response = session.request(data=data, method="POST", path="/api/submit")
         assert "a_test_from_prawcore" in response["json"]["data"]["url"]
         assert key_count == len(data)  # Ensure data is untouched
 
@@ -158,10 +158,10 @@ class TestSession(IntegrationTest):
         with Path("tests/integration/files/white-square.png").open("rb") as fp:
             files = {"file": fp}
             response = session.request(
-                method="POST",
-                path="/r/reddit_api_test/api/upload_sr_img",
                 data=data,
                 files=files,
+                method="POST",
+                path="/r/reddit_api_test/api/upload_sr_img",
             )
         assert "img_src" in response
 
@@ -217,8 +217,8 @@ class TestSession(IntegrationTest):
         assert not exception_info.value.response.headers.get("retry-after")
         assert exception_info.value.response.reason == "Too Many Requests"
         assert exception_info.value.response.json() == {
-            "message": "Too Many Requests",
             "error": 429,
+            "message": "Too Many Requests",
         }
 
     def test_request__too_large(self, script_authorizer):
@@ -228,10 +228,10 @@ class TestSession(IntegrationTest):
             files = {"file": fp}
             with pytest.raises(prawcore.TooLarge) as exception_info:
                 session.request(
-                    method="POST",
-                    path="/r/reddit_api_test/api/upload_sr_img",
                     data=data,
                     files=files,
+                    method="POST",
+                    path="/r/reddit_api_test/api/upload_sr_img",
                 )
         assert exception_info.value.response.status_code == 413
 
@@ -254,7 +254,7 @@ class TestSession(IntegrationTest):
             "page": "config/automoderator",
         }
         with pytest.raises(prawcore.SpecialError) as exception_info:
-            session.request(method="POST", path="r/ttft/api/wiki/edit/", data=data)
+            session.request(data=data, method="POST", path="r/ttft/api/wiki/edit/")
         assert exception_info.value.response.status_code == 415
 
     def test_request__uri_too_long(self, readonly_authorizer):

--- a/tests/unit/test_authenticator.py
+++ b/tests/unit/test_authenticator.py
@@ -25,7 +25,7 @@ class TestTrustedAuthenticator(UnitTest):
     def test_authorize_url__fail_with_implicit(self, trusted_authenticator):
         with pytest.raises(prawcore.InvalidInvocation):
             trusted_authenticator.authorize_url(
-                duration="temporary", scopes=["identity", "read"], state="a_state", implicit=True
+                duration="temporary", implicit=True, scopes=["identity", "read"], state="a_state"
             )
 
     def test_authorize_url__fail_without_redirect_uri(self, trusted_authenticator):
@@ -56,9 +56,9 @@ class TestUntrustedAuthenticator(UnitTest):
         with pytest.raises(prawcore.InvalidInvocation):
             untrusted_authenticator.authorize_url(
                 duration="permanent",
+                implicit=True,
                 scopes=["identity", "read"],
                 state="a_state",
-                implicit=True,
             )
 
     def test_authorize_url__fail_without_redirect_uri(self, untrusted_authenticator):
@@ -72,7 +72,7 @@ class TestUntrustedAuthenticator(UnitTest):
 
     def test_authorize_url__token(self, untrusted_authenticator):
         url = untrusted_authenticator.authorize_url(
-            duration="temporary", scopes=["identity", "read"], state="a_state", implicit=True
+            duration="temporary", implicit=True, scopes=["identity", "read"], state="a_state"
         )
         assert f"client_id={placeholders.client_id}" in url
         assert "duration=temporary" in url

--- a/tests/unit/test_authorizer.py
+++ b/tests/unit/test_authorizer.py
@@ -102,4 +102,4 @@ class TestReadOnlyAuthorizer(UnitTest):
 class TestScriptAuthorizer(UnitTest):
     def test_initialize__with_untrusted_authenticator(self, untrusted_authenticator):
         with pytest.raises(prawcore.InvalidInvocation):
-            prawcore.ScriptAuthorizer(authenticator=untrusted_authenticator, username=None, password=None)
+            prawcore.ScriptAuthorizer(authenticator=untrusted_authenticator, password=None, username=None)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -22,8 +22,8 @@ class TestRateLimiter(UnitTest):
     def _headers(remaining, used, reset):
         return {
             "x-ratelimit-remaining": str(float(remaining)),
-            "x-ratelimit-used": str(used),
             "x-ratelimit-reset": str(reset),
+            "x-ratelimit-used": str(used),
         }
 
     @patch("time.monotonic_ns")

--- a/tests/unit/test_requestor.py
+++ b/tests/unit/test_requestor.py
@@ -34,14 +34,14 @@ class TestRequestor(UnitTest):
     def test_request__default_timeout(self):
         attrs = {"headers": {}, "request.return_value": "response"}
         session = Mock(**attrs)
-        requestor = prawcore.Requestor(user_agent="prawcore:test (by /u/bboe)", session=session)
+        requestor = prawcore.Requestor(session=session, user_agent="prawcore:test (by /u/bboe)")
         requestor.request("get", "https://reddit.com")
         assert session.request.call_args.kwargs["timeout"] == TIMEOUT
 
     def test_request__explicit_timeout(self):
         attrs = {"headers": {}, "request.return_value": "response"}
         session = Mock(**attrs)
-        requestor = prawcore.Requestor(user_agent="prawcore:test (by /u/bboe)", session=session)
+        requestor = prawcore.Requestor(session=session, user_agent="prawcore:test (by /u/bboe)")
         requestor.request("get", "https://reddit.com", timeout=5)
         assert session.request.call_args.kwargs["timeout"] == 5
 
@@ -53,10 +53,10 @@ class TestRequestor(UnitTest):
         override = "REQUEST OVERRIDDEN"
         custom_header = "CUSTOM SESSION HEADER"
         headers = {"session_header": custom_header}
-        attrs = {"request.return_value": override, "headers": headers}
+        attrs = {"headers": headers, "request.return_value": override}
         session = Mock(**attrs)
 
-        requestor = prawcore.Requestor(user_agent="prawcore:test (by /u/bboe)", session=session)
+        requestor = prawcore.Requestor(session=session, user_agent="prawcore:test (by /u/bboe)")
 
         assert requestor._http.headers["User-Agent"] == f"prawcore:test (by /u/bboe) prawcore/{prawcore.__version__}"
         assert requestor._http.headers["session_header"] == custom_header

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,38 +12,6 @@ from vcr.serialize import deserialize, serialize
 from tests.conftest import placeholder_values as _placeholders
 
 
-def ensure_integration_test(cassette):
-    """Ensure test being run is actually an integration test and error if not."""
-    if cassette.write_protected:
-        is_integration_test = cassette.play_count > 0
-        action = "play back"
-    else:  # pragma: no cover
-        is_integration_test = cassette.dirty
-        action = "record"
-    message = f"Cassette did not {action} any requests. This test can be a unit test."
-    assert is_integration_test, message
-
-
-def filter_access_token(response):  # pragma: no cover
-    """Add VCR callback to filter access token."""
-    request_uri = response["url"]
-    if "api/v1/access_token" not in request_uri or response["status"]["code"] != 200:
-        return response
-    body = response["body"]["string"].decode()
-    json_body = json.loads(body)
-    for token_key in ["access", "refresh"]:
-        try:
-            token = json_body[f"{token_key}_token"]
-        except (KeyError, TypeError, ValueError):
-            continue
-        response["body"]["string"] = response["body"]["string"].replace(
-            token.encode("utf-8"),
-            f"<{token_key.upper()}_TOKEN>".encode(),
-        )
-        _placeholders[f"{token_key}_token"] = token
-    return response
-
-
 class CustomPersister(FilesystemPersister):
     """Custom persister to handle placeholders."""
 
@@ -111,4 +79,36 @@ class CustomSerializer:
         else:
             timestamp = timestamp[:i]
         cassette_dict["recorded_at"] = timestamp
-        return f"{json.dumps(cassette_dict, sort_keys=True, indent=2)}\n"
+        return f"{json.dumps(cassette_dict, indent=2, sort_keys=True)}\n"
+
+
+def ensure_integration_test(cassette):
+    """Ensure test being run is actually an integration test and error if not."""
+    if cassette.write_protected:
+        is_integration_test = cassette.play_count > 0
+        action = "play back"
+    else:  # pragma: no cover
+        is_integration_test = cassette.dirty
+        action = "record"
+    message = f"Cassette did not {action} any requests. This test can be a unit test."
+    assert is_integration_test, message
+
+
+def filter_access_token(response):  # pragma: no cover
+    """Add VCR callback to filter access token."""
+    request_uri = response["url"]
+    if "api/v1/access_token" not in request_uri or response["status"]["code"] != 200:
+        return response
+    body = response["body"]["string"].decode()
+    json_body = json.loads(body)
+    for token_key in ["access", "refresh"]:
+        try:
+            token = json_body[f"{token_key}_token"]
+        except (KeyError, TypeError, ValueError):
+            continue
+        response["body"]["string"] = response["body"]["string"].replace(
+            token.encode("utf-8"),
+            f"<{token_key.upper()}_TOKEN>".encode(),
+        )
+        _placeholders[f"{token_key}_token"] = token
+    return response


### PR DESCRIPTION
`main` already runs the [CodeSorter](https://github.com/praw-dev/CodeSorter) pre-commit hook, but pinned to `v0.1.0` (adopted in #325). This bumps the pin to the frozen `v0.2.6` tag and re-sorts the tree with the newer engine.

The diff is therefore just what `v0.2.6` orders beyond `v0.1.0` — primarily module/class-level assignments and keyword arguments in calls — applied across `prawcore/` and the examples and tests. **All changes are behavior-preserving;** the full test suite passes (111 tests) and the package imports cleanly.

Once merged, the pinned hook keeps the source sorted on every commit going forward.
