### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: praw-dev/.github/.github/workflows/ci.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/ci.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
     with:
       min_python: "3.10"
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    name: Lint workflows
+    permissions:
+      contents: read # required to check out the repository
+    uses: praw-dev/.github/.github/workflows/lint.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+name: Lint workflows
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+permissions: {}

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
     with:
       package: prawcore
       version: ${{ inputs.version }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,10 +1,11 @@
 jobs:
   tag_release:
     name: Tag Release
+    permissions:
+      contents: write # required to push the release tag
     uses: praw-dev/.github/.github/workflows/tag_release.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
 name: Tag Release
 on:
   push:
     branches: [ main, release_test ]
-permissions:
-  contents: write
+permissions: {}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -3,7 +3,7 @@ jobs:
     name: Tag Release
     permissions:
       contents: write # required to push the release tag
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
Hardens this repo's GitHub Actions workflows, part of an org-wide pass driven by [zizmor](https://docs.zizmor.sh/).

## Changes

- **Scope `GITHUB_TOKEN` permissions to the job level** in `tag_release.yml`, with a deny-all `permissions: {}` default at the top level. Resolves zizmor's high-severity `excessive-permissions` finding; no change to the effective granted permissions.
- **Add `lint.yml`** — a thin caller of the new reusable `actionlint` + `zizmor` workflow in `praw-dev/.github` (pinned to v1.5.0), so workflow files are linted on every push/PR.