### PR TITLE
Bump dependabot automerge workflow to v1.9.0

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -2,9 +2,11 @@ jobs:
   dependabot_automerge:
     name: Dependabot automerge
     permissions:
-      contents: write # required to merge the pull request
-      pull-requests: write # required to enable auto-merge on the pull request
-    uses: praw-dev/.github/.github/workflows/dependabot_automerge.yml@68c4e3402dc6c829ac9a1a787a663baabd21388b # v1.7.0
+      pull-requests: read # required by fetch-metadata; the merge uses an app token
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    uses: praw-dev/.github/.github/workflows/dependabot_automerge.yml@ec52651e5b4e1de96c58ed3652e662588fb62dbb # v1.9.0
 name: Dependabot automerge
 on:
   pull_request:


### PR DESCRIPTION
Bumps the pinned `dependabot_automerge` reusable workflow to [v1.9.0](https://github.com/praw-dev/.github/pull/28) and passes the app-token secrets it now requires.

Dependabot auto-merge has never actually merged anything. The 2026-08-01 batch was its first real run and it failed:

```
GraphQL: Pull request User is not authorized for this protected branch (enablePullRequestAutoMerge)
```

`main` restricts pushes to the `praw-dev-automation` app, and `GITHUB_TOKEN` acts as `github-actions[bot]`, which is not on that allowlist. v1.9.0 mints an app token instead, matching `pre-commit_autoupdate.yml`.

- Pass `APP_ID` / `APP_PRIVATE_KEY` (now set as org-level **Dependabot** secrets, since Dependabot runs cannot read Actions secrets).
- Narrow the job permissions from `contents: write` + `pull-requests: write` to `pull-requests: read`; `GITHUB_TOKEN` is now only used by `fetch-metadata`.

Next Dependabot batch (~2026-09-01) is the test.