### PR TITLE
Split Dependabot groups by semver level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
   - package-ecosystem: uv
     directory: /
     schedule:
@@ -24,3 +32,11 @@ updates:
       python:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
Splits each Dependabot group by semver level so a single major update no longer blocks every other update in its group.

Today `dependabot/fetch-metadata` reports the *highest* semver change in a PR, so one major anywhere in a group marks the whole PR `semver-major` and the auto-merge guard skips it. praw-dev/prawcore#353 (9 updates) and praw-dev/.github#31 (4 updates) are both parked for exactly this reason.

After this change each ecosystem produces up to two PRs:

- `<group>` — minor/patch only, auto-merges once required checks pass.
- `<group>-major` — majors only, still parked for manual review.

This does not reduce how much you review; it stops majors from holding non-major updates hostage.