### PR TITLE
Bump praw-dev/.github reusable workflows to v1.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: praw-dev/.github/.github/workflows/ci.yml@ec52651e5b4e1de96c58ed3652e662588fb62dbb # v1.9.0
+    uses: praw-dev/.github/.github/workflows/ci.yml@97050199f9773073e4360d798053b7fb342e4c1f # v1.11.0
     with:
       min_python: "3.10"
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -6,7 +6,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/dependabot_automerge.yml@ec52651e5b4e1de96c58ed3652e662588fb62dbb # v1.9.0
+    uses: praw-dev/.github/.github/workflows/dependabot_automerge.yml@97050199f9773073e4360d798053b7fb342e4c1f # v1.11.0
 name: Dependabot automerge
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     name: Lint workflows
     permissions:
       contents: read # required to check out the repository
-    uses: praw-dev/.github/.github/workflows/lint.yml@ec52651e5b4e1de96c58ed3652e662588fb62dbb # v1.9.0
+    uses: praw-dev/.github/.github/workflows/lint.yml@97050199f9773073e4360d798053b7fb342e4c1f # v1.11.0
 name: Lint workflows
 on:
   pull_request:

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@ec52651e5b4e1de96c58ed3652e662588fb62dbb # v1.9.0
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@97050199f9773073e4360d798053b7fb342e4c1f # v1.11.0
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@ec52651e5b4e1de96c58ed3652e662588fb62dbb # v1.9.0
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@97050199f9773073e4360d798053b7fb342e4c1f # v1.11.0
     with:
       package: prawcore
       version: ${{ inputs.version }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -3,7 +3,7 @@ jobs:
     name: Tag Release
     permissions:
       contents: write # required to push the release tag
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@ec52651e5b4e1de96c58ed3652e662588fb62dbb # v1.9.0
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@97050199f9773073e4360d798053b7fb342e4c1f # v1.11.0
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
Bumps every pinned praw-dev/.github reusable workflow from v1.9.0 to v1.11.0.

**v1.11.0** — removes the workflow-level `concurrency` block from the reusable `lint.yml`. That block made every `workflow_call` of it fail at startup, so `Lint workflows` has produced no jobs, no logs, and no check run in this repository since 2026-06-15: actionlint and zizmor have not actually run here for nearly two months. See praw-dev/.github#37.

**v1.10.0** — Dependabot auto-merges major `github-actions` bumps (other ecosystems still stop for review, see praw-dev/.github#35), plus newer action pins consumed by the shared workflows: `actions/checkout` v7.0.1, `actions/setup-python` v7.0.0, `actions/stale` v11.0.0, `astral-sh/setup-uv` v9.0.0.

Bumped manually rather than waiting for Dependabot, whose one-day cooldown would delay restoring lint until tomorrow.

Note: the `Lint workflows` check on this PR is the first genuine actionlint/zizmor run here since June, so any findings are pre-existing rather than caused by this bump.